### PR TITLE
Allow duplicate headers: merge values into array

### DIFF
--- a/tests/SimpleExcelReaderTest.php
+++ b/tests/SimpleExcelReaderTest.php
@@ -129,4 +129,25 @@ class SimpleExcelReaderTest extends TestCase
 
         $this->assertEquals($path, $reader->getPath());
     }
+
+    /** @test */
+    public function it_allows_duplicate_columns()
+    {
+        $rows = SimpleExcelReader::create($this->getStubPath('duplicate-columns.csv'))
+            ->getRows()
+            ->toArray();
+
+        $this->assertEquals([
+            [
+                'email' => 'john@example.com',
+                'first_name' => 'john',
+                'last_name' => ['doe', 'deer'],
+            ],
+            [
+                'email' => 'mary-jane@example.com',
+                'first_name' => 'mary jane',
+                'last_name' => ['doe', 'deer'],
+            ],
+        ], $rows);
+    }
 }

--- a/tests/stubs/duplicate-columns.csv
+++ b/tests/stubs/duplicate-columns.csv
@@ -1,0 +1,3 @@
+email,first_name,last_name,last_name
+john@example.com,john,doe,deer
+mary-jane@example.com,mary jane,doe,deer


### PR DESCRIPTION
This solves the problem of spreadsheets containing duplicate headers (which is allowed in Excel).
It will concatenate the values into an array.

-----

Let me know if you're interested in this solution: maybe the problem is too specific, but I've encountered quite some spreadsheets from clients containing duplicate column headers.