### PR TITLE
Add 'take' and 'skip' functions to reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,12 +102,21 @@ Under the hood this package uses the [box/spout](https://github.com/box/spout) p
 $reader = SimpleExcelReader::create($pathToCsv)->getReader();
 ```
 
-#### Offset & Limit
+#### Limiting the result set
 
-The `take` method allows you to specify a limit on how many rows are returned in the LazyCollection. The `skip` method allows you to define which row to start reading data from.
+The `take` method allows you to specify a limit on how many rows should be returned. 
 
 ```php
 // $rows is an instance of Illuminate\Support\LazyCollection
+$rows = SimpleExcelReader::create($pathToCsv)
+    ->take(5)
+    ->getRows();
+```
+
+The `skip` method allows you to define which row to start reading data from. In this example we get rows 11 to 16.
+
+
+```php
 $rows = SimpleExcelReader::create($pathToCsv)
     ->skip(10)
     ->take(5)

--- a/README.md
+++ b/README.md
@@ -102,6 +102,18 @@ Under the hood this package uses the [box/spout](https://github.com/box/spout) p
 $reader = SimpleExcelReader::create($pathToCsv)->getReader();
 ```
 
+#### Offset & Limit
+
+The `take` method allows you to specify a limit on how many rows are returned in the LazyCollection. The `skip` method allows you to define which row to start reading data from.
+
+```php
+// $rows is an instance of Illuminate\Support\LazyCollection
+$rows = SimpleExcelReader::create($pathToCsv)
+    ->skip(10)
+    ->take(5)
+    ->getRows();
+```
+
 ### Writing files
 
 Here's how you can write a CSV file:

--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -18,11 +18,11 @@ class SimpleExcelReader
 
     private bool $processHeader = true;
 
-    private $skip = 0;
+    private int $skip = 0;
 
-    private $limit = 0;
+    private int $limit = 0;
 
-    private $use_limit = false;
+    private bool $useLimit = false;
 
     public static function create(string $file)
     {
@@ -67,17 +67,17 @@ class SimpleExcelReader
         return $this->reader;
     }
 
-    public function skip($count)
+    public function skip(int $count): SimpleExcelReader
     {
         $this->skip = $count;
 
         return $this;
     }
 
-    public function take($count)
+    public function take(int $count): SimpleExcelReader
     {
         $this->limit = $count;
-        $this->use_limit = true;
+        $this->useLimit = true;
 
         return $this;
     }
@@ -110,7 +110,7 @@ class SimpleExcelReader
             while ($this->rowIterator->valid() && $this->skip--) {
                 $this->rowIterator->next();
             }
-            while ($this->rowIterator->valid() && (! $this->use_limit || $this->limit--)) {
+            while ($this->rowIterator->valid() && (! $this->useLimit || $this->limit--)) {
                 $row = $this->rowIterator->current();
 
                 yield $this->getValueFromRow($row);

--- a/tests/SimpleExcelReaderTest.php
+++ b/tests/SimpleExcelReaderTest.php
@@ -150,4 +150,38 @@ class SimpleExcelReaderTest extends TestCase
             ],
         ], $rows);
     }
+
+    /** @test */
+    public function it_can_use_an_offset()
+    {
+        $rows = SimpleExcelReader::create($this->getStubPath('header-and-rows.csv'))
+            ->skip(1)
+            ->getRows()
+            ->toArray();
+
+        $this->assertEquals([
+            [
+                'email' => 'mary-jane@example.com',
+                'first_name' => 'mary jane',
+                'last_name' => 'doe',
+            ],
+        ], $rows);
+    }
+
+    /** @test */
+    public function it_can_take_a_limit()
+    {
+        $rows = SimpleExcelReader::create($this->getStubPath('header-and-rows.csv'))
+            ->take(1)
+            ->getRows()
+            ->toArray();
+
+        $this->assertEquals([
+            [
+                'email' => 'john@example.com',
+                'first_name' => 'john',
+                'last_name' => 'doe',
+            ],
+        ], $rows);
+    }
 }


### PR DESCRIPTION
Closes #34 

Instead of `offset` and `limit`, I used `take` and `skip` to follow the conventions from LazyCollections.