### PR TITLE
Add Header Styling Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,11 @@ $style = (new StyleBuilder())
 
 $writer->addRow(['values, 'of', 'the', 'row'], $style)
 ```
+To style your HeaderRow simply call the `setHeaderStyle($style)` Method.
+
+```php
+$writer->setHeaderStyle($style);
+```
 
 For more information on styles head over to [the Spout docs](https://opensource.box.com/spout/docs/#styling).
 

--- a/src/SimpleExcelWriter.php
+++ b/src/SimpleExcelWriter.php
@@ -18,6 +18,8 @@ class SimpleExcelWriter
 
     private int $numberOfRows = 0;
 
+    private $headerStyle = null;
+
     public static function create(string $file)
     {
         $simpleExcelWriter = new static($file);
@@ -66,6 +68,14 @@ class SimpleExcelWriter
     }
 
     /**
+     *  @param \Box\Spout\Common\Entity\Style\Style $style
+     */
+    public function setHeaderStyle($style)
+    {
+        $this->headerStyle = $style;
+    }
+
+    /**
      * @param \Box\Spout\Common\Entity\Row|array $row
      * @param \Box\Spout\Common\Entity\Style\Style|null $style
      */
@@ -92,7 +102,7 @@ class SimpleExcelWriter
         foreach ($rows as $row) {
             $this->addRow($row);
         }
-        
+
         return $this;
     }
 
@@ -100,7 +110,7 @@ class SimpleExcelWriter
     {
         $headerValues = array_keys($row);
 
-        $headerRow = WriterEntityFactory::createRowFromArray($headerValues);
+        $headerRow = WriterEntityFactory::createRowFromArray($headerValues, $this->headerStyle);
 
         $this->writer->addRow($headerRow);
         $this->numberOfRows++;


### PR DESCRIPTION
This PR adds a method for Styling the Header Row. In the current implementation styling only applies for non-header rows. 