### PR TITLE
Allow setting the writer/reader type manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ $rows->each(function(array $rowProperties) {
 
 Reading an Excel file is identical to reading a CSV file. Just make sure that the path given to the `create` method of `SimpleExcelReader` ends with `xlsx`.
 
+#### Manually setting the file type
+
+You can pass the file type to the `create` method of `SimpleExcelReader` as the second, optional argument:
+
+```php
+SimpleExcelReader::create($pathToFile, 'csv');
+```
+
 #### Working with LazyCollections
 
 `getRows` will return an instance of [`Illuminate\Support\LazyCollection`](https://laravel.com/docs/master/collections#lazy-collections). This class is part of the Laravel framework. Behind the scenes generators are used, so memory usage will be low, even for large files.
@@ -102,7 +110,7 @@ $reader = SimpleExcelReader::create($pathToCsv)->getReader();
 
 #### Limiting the result set
 
-The `take` method allows you to specify a limit on how many rows should be returned. 
+The `take` method allows you to specify a limit on how many rows should be returned.
 
 ```php
 // $rows is an instance of Illuminate\Support\LazyCollection
@@ -148,6 +156,14 @@ Jane,Doe
 #### Writing an Excel file
 
 Writing an Excel file is identical to writing a csv. Just make sure that the path given to the `create` method of `SimpleExcelWriter` ends with `xlsx`.
+
+#### Manually setting the file type
+
+You can pass the file type to the `create` method of `SimpleExcelWriter` as the second, optional argument:
+
+```php
+SimpleExcelWriter::create('php://output', 'csv');
+```
 
 #### Streaming an Excel file to the browser
 

--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -4,6 +4,7 @@ namespace Spatie\SimpleExcel;
 
 use Box\Spout\Common\Entity\Row;
 use Box\Spout\Reader\Common\Creator\ReaderEntityFactory;
+use Box\Spout\Reader\Common\Creator\ReaderFactory;
 use Box\Spout\Reader\IteratorInterface;
 use Box\Spout\Reader\ReaderInterface;
 use Illuminate\Support\LazyCollection;
@@ -24,16 +25,20 @@ class SimpleExcelReader
 
     private bool $useLimit = false;
 
-    public static function create(string $file)
+    public static function create(string $file, ?string $type = null)
     {
-        return new static($file);
+        return new static($file, $type);
     }
 
-    public function __construct(string $path)
+    public function __construct(string $path, ?string $type = null)
     {
         $this->path = $path;
 
-        $this->reader = ReaderEntityFactory::createReaderFromFile($this->path);
+        if ($type) {
+            $this->reader = ReaderFactory::createFromType($type);
+        } else {
+            $this->reader = ReaderEntityFactory::createReaderFromFile($this->path);
+        }
     }
 
     public function getPath(): string

--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -25,20 +25,18 @@ class SimpleExcelReader
 
     private bool $useLimit = false;
 
-    public static function create(string $file, ?string $type = null)
+    public static function create(string $file, string $type = '')
     {
         return new static($file, $type);
     }
 
-    public function __construct(string $path, ?string $type = null)
+    public function __construct(string $path, string $type = '')
     {
         $this->path = $path;
 
-        if ($type) {
-            $this->reader = ReaderFactory::createFromType($type);
-        } else {
-            $this->reader = ReaderEntityFactory::createReaderFromFile($this->path);
-        }
+        $this->reader = $type ?
+            ReaderFactory::createFromType($type) :
+            ReaderEntityFactory::createReaderFromFile($this->path);
     }
 
     public function getPath(): string

--- a/src/SimpleExcelWriter.php
+++ b/src/SimpleExcelWriter.php
@@ -20,29 +20,33 @@ class SimpleExcelWriter
 
     private $headerStyle = null;
 
-    public static function create(string $file)
+    public static function create(string $file, ?string $type = null)
     {
-        $simpleExcelWriter = new static($file);
+        $simpleExcelWriter = new static($file, $type);
 
         $simpleExcelWriter->getWriter()->openToFile($file);
 
         return $simpleExcelWriter;
     }
 
-    public static function streamDownload(string $downloadName)
+    public static function streamDownload(string $downloadName, ?string $type = null)
     {
-        $simpleExcelWriter = new static($downloadName);
+        $simpleExcelWriter = new static($downloadName, $type);
 
         $simpleExcelWriter->getWriter()->openToBrowser($downloadName);
 
         return $simpleExcelWriter;
     }
 
-    protected function __construct(string $path)
+    protected function __construct(string $path, ?string $type = null)
     {
-        $this->writer = WriterEntityFactory::createWriterFromFile($path);
-
         $this->path = $path;
+
+        if ($type) {
+            $this->writer = WriterEntityFactory::createWriter($type);
+        } else {
+            $this->writer = WriterEntityFactory::createWriterFromFile($this->path);
+        }
     }
 
     public function getPath(): string

--- a/src/SimpleExcelWriter.php
+++ b/src/SimpleExcelWriter.php
@@ -20,7 +20,7 @@ class SimpleExcelWriter
 
     private $headerStyle = null;
 
-    public static function create(string $file, ?string $type = null)
+    public static function create(string $file, string $type = '')
     {
         $simpleExcelWriter = new static($file, $type);
 
@@ -29,7 +29,7 @@ class SimpleExcelWriter
         return $simpleExcelWriter;
     }
 
-    public static function streamDownload(string $downloadName, ?string $type = null)
+    public static function streamDownload(string $downloadName, string $type = '')
     {
         $simpleExcelWriter = new static($downloadName, $type);
 
@@ -38,15 +38,13 @@ class SimpleExcelWriter
         return $simpleExcelWriter;
     }
 
-    protected function __construct(string $path, ?string $type = null)
+    protected function __construct(string $path, string $type = '')
     {
         $this->path = $path;
 
-        if ($type) {
-            $this->writer = WriterEntityFactory::createWriter($type);
-        } else {
-            $this->writer = WriterEntityFactory::createWriterFromFile($this->path);
-        }
+        $this->writer = $type ?
+            WriterEntityFactory::createWriter($type) :
+            WriterEntityFactory::createWriterFromFile($this->path);
     }
 
     public function getPath(): string

--- a/tests/SimpleExcelReaderTest.php
+++ b/tests/SimpleExcelReaderTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\SimpleExcel\Tests;
 
+use Box\Spout\Reader\CSV\Reader;
 use Spatie\SimpleExcel\SimpleExcelReader;
 
 class SimpleExcelReaderTest extends TestCase
@@ -206,5 +207,13 @@ class SimpleExcelReaderTest extends TestCase
 
         $this->assertNotNull($firstRow);
         $this->assertNotNull($firstRowAgain);
+    }
+
+    /** @test */
+    public function it_allows_setting_the_reader_type_manually()
+    {
+        $reader = SimpleExcelReader::create('php://input', 'csv');
+
+        $this->assertInstanceOf(Reader::class, $reader->getReader());
     }
 }

--- a/tests/SimpleExcelWriterTest.php
+++ b/tests/SimpleExcelWriterTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\SimpleExcel\Tests;
 
+use Box\Spout\Writer\CSV\Writer;
 use Spatie\SimpleExcel\SimpleExcelWriter;
 use Spatie\Snapshots\MatchesSnapshots;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
@@ -120,5 +121,13 @@ class SimpleExcelWriterTest extends TestCase
         $writer = SimpleExcelWriter::create($this->pathToCsv);
 
         $this->assertEquals($this->pathToCsv, $writer->getPath());
+    }
+
+    /** @test */
+    public function it_allows_setting_the_writer_type_manually()
+    {
+        $writer = SimpleExcelWriter::create('php://output', 'csv');
+
+        $this->assertInstanceOf(Writer::class, $writer->getWriter());
     }
 }


### PR DESCRIPTION
I ran into a situation where I needed to set the file type for the writer manually. This PR adds an optional 2nd argument to both the Reader and Writer, so it's possible to set the type when it cannot be determined from the filename.

A concrete use-case is when trying to read from or write to the PHP input/output stream.

In my specific scenario, even though this package has built-in support for stream downloads, it didn't work inside a Laravel Livewire component, which expected a Laravel StreamDownload. I had to be able to write to the output stream, but since the stream name can't contain a file extension, I needed to specify the type manually. Here's how it would work with this PR in place:

```php
return response()->streamDownload(function () use ($builder) {
    $writer = SimpleExcelWriter::create('php://output', 'csv');

    $builder->each(fn ($product) => $writer->addRow($product->toArray()));
}, 'products.csv');
```

Since this is an optional argument, there should be no breaking changes. I also added the argument to `SimpleExcelWriter::streamDownload` and `SimpleExcelReader` methods, for consistency.

Let me know what you think and if the PR needs any tweaks. 