### PR TITLE
use setHeaderStyle fluently

### DIFF
--- a/src/SimpleExcelWriter.php
+++ b/src/SimpleExcelWriter.php
@@ -75,6 +75,8 @@ class SimpleExcelWriter
     public function setHeaderStyle($style)
     {
         $this->headerStyle = $style;
+        
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Allow to fluently set the headerstyle; e.g.

```php
return SimpleExcelWriter::streamDownload($outputFilename)
    ->setHeaderStyle($style)
    ->addRows($rows)
    ->toBrowser();
```
... instead of...

```php
$writer = SimpleExcelWriter::streamDownload($outputFilename);
$writer->setHeaderStyle($style);

return $writer
    ->addRows($rows)
    ->toBrowser();
```