### PR TITLE
enable disabling BOM on writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,9 +300,13 @@ $writerWithoutAutomaticHeader->getNumberOfRows() // returns 2
 
 You can also disable adding a BOM to the start of the file. BOM must be disabled on create and cannot be disabled after creation of the writer.
 
+A BOM, or byte order mark, indicates a number of things for the file being written including the file being unicode as well as it's UTF encoding type.
+
 ```php
-SimpleExcelWriter::create($this->pathToCsv, $type, fn ($writer) => $writer->setShouldAddBOM(false));
+SimpleExcelWriter::createWithoutBom($this->pathToCsv, $type);
 ```
+
+Additional information about BOM can be found [here](https://en.wikipedia.org/wiki/Byte_order_mark).
 
 #### Manually working with the writer object
 

--- a/README.md
+++ b/README.md
@@ -296,6 +296,14 @@ $writerWithAutomaticHeader = SimpleExcelWriter::create($this->pathToCsv)
 $writerWithoutAutomaticHeader->getNumberOfRows() // returns 2
 ```
 
+#### Disable BOM
+
+You can also disable adding a BOM to the start of the file. BOM must be disabled on create and cannot be disabled after creation of the writer.
+
+```php
+SimpleExcelWriter::create($this->pathToCsv, $type, fn ($writer) => $writer->setShouldAddBOM(false));
+```
+
 #### Manually working with the writer object
 
 Under the hood this package uses the [box/spout](https://github.com/box/spout) package. You can get to the underlying writer that implements `\Box\Spout\Reader\WriterInterface` by calling the `getWriter` method.

--- a/src/SimpleExcelWriter.php
+++ b/src/SimpleExcelWriter.php
@@ -35,6 +35,11 @@ class SimpleExcelWriter
         return $simpleExcelWriter;
     }
 
+    public static function createWithoutBom(string $file, string $type = '')
+    {
+        return static::create($file, $type, fn ($writer) => $writer->setShouldAddBOM(false));
+    }
+
     public static function streamDownload(string $downloadName, string $type = '', callable $writerCallback = null)
     {
         $simpleExcelWriter = new static($downloadName, $type);

--- a/src/SimpleExcelWriter.php
+++ b/src/SimpleExcelWriter.php
@@ -20,14 +20,14 @@ class SimpleExcelWriter
 
     private $headerStyle = null;
 
-    public static function create(string $file, string $type = '', callable $writerCallback = null)
+    public static function create(string $file, string $type = '', callable $configureWriter = null)
     {
         $simpleExcelWriter = new static($file, $type);
 
         $writer = $simpleExcelWriter->getWriter();
 
-        if ($writerCallback) {
-            $writerCallback($writer);
+        if ($configureWriter) {
+            $configureWriter($writer);
         }
 
         $writer->openToFile($file);

--- a/src/SimpleExcelWriter.php
+++ b/src/SimpleExcelWriter.php
@@ -20,20 +20,32 @@ class SimpleExcelWriter
 
     private $headerStyle = null;
 
-    public static function create(string $file, string $type = '')
+    public static function create(string $file, string $type = '', callable $writerCallback = null)
     {
         $simpleExcelWriter = new static($file, $type);
 
-        $simpleExcelWriter->getWriter()->openToFile($file);
+        $writer = $simpleExcelWriter->getWriter();
+
+        if ($writerCallback) {
+            $writerCallback($writer);
+        }
+
+        $writer->openToFile($file);
 
         return $simpleExcelWriter;
     }
 
-    public static function streamDownload(string $downloadName, string $type = '')
+    public static function streamDownload(string $downloadName, string $type = '', callable $writerCallback = null)
     {
         $simpleExcelWriter = new static($downloadName, $type);
 
-        $simpleExcelWriter->getWriter()->openToBrowser($downloadName);
+        $writer = $simpleExcelWriter->getWriter();
+
+        if ($writerCallback) {
+            $writerCallback($writer);
+        }
+
+        $writer->openToBrowser($downloadName);
 
         return $simpleExcelWriter;
     }
@@ -75,7 +87,7 @@ class SimpleExcelWriter
     public function setHeaderStyle($style)
     {
         $this->headerStyle = $style;
-        
+
         return $this;
     }
 

--- a/tests/SimpleExcelWriterTest.php
+++ b/tests/SimpleExcelWriterTest.php
@@ -130,4 +130,16 @@ class SimpleExcelWriterTest extends TestCase
 
         $this->assertInstanceOf(Writer::class, $writer->getWriter());
     }
+
+    /** @test */
+    public function it_can_write_a_csv_without_bom()
+    {
+        $writer = SimpleExcelWriter::create($this->pathToCsv, '', fn ($writer) => $writer->setShouldAddBOM(false))
+            ->addRow([
+                'first_name' => 'Jane',
+                'last_name' => 'Doe',
+            ]);
+
+        $this->assertMatchesFileSnapshot($this->pathToCsv);
+    }
 }

--- a/tests/SimpleExcelWriterTest.php
+++ b/tests/SimpleExcelWriterTest.php
@@ -134,7 +134,7 @@ class SimpleExcelWriterTest extends TestCase
     /** @test */
     public function it_can_write_a_csv_without_bom()
     {
-        $writer = SimpleExcelWriter::create($this->pathToCsv, '', fn ($writer) => $writer->setShouldAddBOM(false))
+        $writer = SimpleExcelWriter::createWithoutBom($this->pathToCsv)
             ->addRow([
                 'first_name' => 'Jane',
                 'last_name' => 'Doe',

--- a/tests/__snapshots__/files/SimpleExcelWriterTest__it_can_write_a_csv_without_bom__1.csv
+++ b/tests/__snapshots__/files/SimpleExcelWriterTest__it_can_write_a_csv_without_bom__1.csv
@@ -1,0 +1,2 @@
+first_name,last_name
+Jane,Doe


### PR DESCRIPTION
This was the first pass on enabling this functionality, and closely mirrors what I had in the discussion notes.

I would wonder if potentially a shorthand would be helpful, like adding an explicit method instead like:
`createWithoutBOM($path, $type)`

With the current code changes, it'd be as simple as just calling create with a pre-defined callback.

This way it would keep the clean method signature set, but at least there's a start here for further more concrete discussion.