### PR TITLE
Add option to convert headers to snake_case format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ $rows = SimpleExcelReader::create($pathToCsv)
 `trimHeaderRow()` additionally accepts a param to specify what characters to trim. This param can utilize the same functionality allowed by the trim function's `$characters` definition including a range of characters.
 
 
-#### Convert headers to ```snake_case``` format
+#### Convert headers to snake_case
 
-If you would like all the headers to be converted to snake_case format, use the the `headersToSnakeCase()` method.
+If you would like all the headers to be converted to snake_case, use the the `headersToSnakeCase()` method.
 
 ```csv
 Email,First Name,Last Name

--- a/README.md
+++ b/README.md
@@ -144,7 +144,28 @@ $rows = SimpleExcelReader::create($pathToCsv)
     ->each(function(array $rowProperties) {
         // rowProperties converted to snake_case
         // ['email' => 'john@example', 'first_name' => 'John', 'last_name' => 'doe']
-});
+    });
+```
+
+#### Custom headers formatter
+
+You can use a custom formatter to change the headers using the ```headerRowFormatter``` method and passing a closure.
+
+```csv
+email,first_name,last_name
+john@example.com,john,doe
+mary-jane@example.com,mary jane,doe
+```
+
+```php
+$rows = SimpleExcelReader::create($pathToCsv)
+    ->headerRowFormatter(function($header) {
+        return $header . '_simple_excel';
+    })
+    ->getRows()
+    ->each(function(array $rowProperties) {
+        // ['email_simple_excel' => 'john@example', 'first_name_simple_excel' => 'John', 'last_name_simple_excel' => 'doe']
+    });
 ```
 
 #### Manually working with the reader object

--- a/README.md
+++ b/README.md
@@ -126,6 +126,27 @@ $rows = SimpleExcelReader::create($pathToCsv)
 
 `trimHeaderRow()` additionally accepts a param to specify what characters to trim. This param can utilize the same functionality allowed by the trim function's `$characters` definition including a range of characters.
 
+
+#### Convert headers to ```snake_case``` format
+
+If you would like all the headers to be converted to snake_case format, use the the `headersToSnakeCase()` method.
+
+```csv
+Email,First Name,Last Name
+john@example.com,john,doe
+mary-jane@example.com,mary jane,doe
+```
+
+```php
+$rows = SimpleExcelReader::create($pathToCsv)
+    ->headersToSnakeCase()
+    ->getRows()
+    ->each(function(array $rowProperties) {
+        // rowProperties converted to snake_case
+        // ['email' => 'john@example', 'first_name' => 'John', 'last_name' => 'doe']
+});
+```
+
 #### Manually working with the reader object
 
 Under the hood this package uses the [box/spout](https://github.com/box/spout) package. You can get to the underlying reader that implements `\Box\Spout\Reader\ReaderInterface` by calling the `getReader` method.

--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -154,9 +154,9 @@ class SimpleExcelReader
 
         if ($this->headersToSnakeCase) {
             $headers = array_map(function ($header) {
-                return strtolower(preg_replace('/(.)(?=[A-Z])/', '_', $header));
-                // return strtolower(preg_replace('/(?<!^)[A-Z]/', '_', $header));
-                // return call_user_func_array('trim', array_filter([$header, $this->trimHeaderCharacters]));
+                return str_replace(
+                    ' ', '_', strtolower(preg_replace('/(?<=\d)(?=[A-Za-z])|(?<=[A-Za-z])(?=\d)|(?<=[a-z])(?=[A-Z])/', '_', trim($header)))
+                );
             }, $headers);   
         }
 

--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -25,6 +25,8 @@ class SimpleExcelReader
 
     private $trimHeaderCharacters = null;
 
+    private $headerRowFormatter;
+
     private int $skip = 0;
 
     private int $limit = 0;
@@ -154,6 +156,10 @@ class SimpleExcelReader
             $headers = $this->convertHeaders([$this, 'toSnakecase'], $headers);
         }
 
+        if ($this->headerRowFormatter) {
+            $headers = $this->convertHeaders($this->headerRowFormatter, $headers);   
+        }
+
         return $headers;
     }
 
@@ -162,6 +168,13 @@ class SimpleExcelReader
         return array_map(function ($header) use ($callback) {
             return call_user_func($callback, $header);
         }, $headers);
+    }
+
+    public function headerRowFormatter(callable $callback) 
+    {
+        $this->headerRowFormatter = $callback;
+
+        return $this;
     }
 
     protected function trim(string $header): string 

--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -21,6 +21,8 @@ class SimpleExcelReader
 
     private bool $trimHeader = false;
 
+    private bool $headersToSnakeCase = false;
+
     private $trimHeaderCharacters = null;
 
     private int $skip = 0;
@@ -73,6 +75,13 @@ class SimpleExcelReader
     {
         $this->trimHeader = true;
         $this->trimHeaderCharacters = $characters;
+
+        return $this;
+    }
+
+    public function headersToSnakeCase()
+    {
+        $this->headersToSnakeCase = true;
 
         return $this;
     }
@@ -141,6 +150,14 @@ class SimpleExcelReader
             $headers = array_map(function ($header) {
                 return call_user_func_array('trim', array_filter([$header, $this->trimHeaderCharacters]));
             }, $headers);
+        }
+
+        if ($this->headersToSnakeCase) {
+            $headers = array_map(function ($header) {
+                return strtolower(preg_replace('/(.)(?=[A-Z])/', '_', $header));
+                // return strtolower(preg_replace('/(?<!^)[A-Z]/', '_', $header));
+                // return call_user_func_array('trim', array_filter([$header, $this->trimHeaderCharacters]));
+            }, $headers);   
         }
 
         return $headers;

--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -157,19 +157,19 @@ class SimpleExcelReader
         return $headers;
     }
 
-    private function convertHeaders(callable $callback, array $headers): array
+    protected function convertHeaders(callable $callback, array $headers): array
     {
         return array_map(function ($header) use ($callback) {
             return call_user_func($callback, $header);
         }, $headers);
     }
 
-    private function trim(string $header): string 
+    protected function trim(string $header): string 
     {
         return call_user_func_array('trim', array_filter([$header, $this->trimHeaderCharacters]));
     } 
 
-    private function toSnakeCase(string $header): string 
+    protected function toSnakeCase(string $header): string 
     {
         return str_replace(
             ' ', '_', strtolower(preg_replace('/(?<=\d)(?=[A-Za-z])|(?<=[A-Za-z])(?=\d)|(?<=[a-z])(?=[A-Z])/', '_', trim($header)))

--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -147,20 +147,33 @@ class SimpleExcelReader
     protected function processHeaderRow(array $headers): array
     {
         if ($this->trimHeader) {
-            $headers = array_map(function ($header) {
-                return call_user_func_array('trim', array_filter([$header, $this->trimHeaderCharacters]));
-            }, $headers);
+            $headers = $this->convertHeaders([$this, 'trim'], $headers);
         }
 
         if ($this->headersToSnakeCase) {
-            $headers = array_map(function ($header) {
-                return str_replace(
-                    ' ', '_', strtolower(preg_replace('/(?<=\d)(?=[A-Za-z])|(?<=[A-Za-z])(?=\d)|(?<=[a-z])(?=[A-Z])/', '_', trim($header)))
-                );
-            }, $headers);   
+            $headers = $this->convertHeaders([$this, 'toSnakecase'], $headers);
         }
 
         return $headers;
+    }
+
+    private function convertHeaders(callable $callback, array $headers): array
+    {
+        return array_map(function ($header) use ($callback) {
+            return call_user_func($callback, $header);
+        }, $headers);
+    }
+
+    private function trim(string $header): string 
+    {
+        return call_user_func_array('trim', array_filter([$header, $this->trimHeaderCharacters]));
+    } 
+
+    private function toSnakeCase(string $header): string 
+    {
+        return str_replace(
+            ' ', '_', strtolower(preg_replace('/(?<=\d)(?=[A-Za-z])|(?<=[A-Za-z])(?=\d)|(?<=[a-z])(?=[A-Z])/', '_', trim($header)))
+        );
     }
 
     protected function getValueFromRow(Row $row): array

--- a/tests/SimpleExcelReaderTest.php
+++ b/tests/SimpleExcelReaderTest.php
@@ -260,4 +260,26 @@ class SimpleExcelReaderTest extends TestCase
             ],
         ], $rows);
     }
+
+    /** @test */
+    public function it_can_convert_headers_to_snake_case()
+    {
+        $rows = SimpleExcelReader::create($this->getStubPath('headers-not-snake-case.csv'))
+            ->headersToSnakeCase()
+            ->getRows()
+            ->toArray();
+
+        $this->assertEquals([
+            [
+                'email' => 'john@example.com',
+                'first_name' => 'john',
+                'last_name' => 'doe',
+            ],
+            [
+                'email' => 'mary-jane@example.com',
+                'first_name' => 'mary jane',
+                'last_name' => 'doe',
+            ],
+        ], $rows);
+    }
 }

--- a/tests/SimpleExcelReaderTest.php
+++ b/tests/SimpleExcelReaderTest.php
@@ -274,11 +274,13 @@ class SimpleExcelReaderTest extends TestCase
                 'email' => 'john@example.com',
                 'first_name' => 'john',
                 'last_name' => 'doe',
+                'job_title' => 'male nutter'
             ],
             [
                 'email' => 'mary-jane@example.com',
                 'first_name' => 'mary jane',
                 'last_name' => 'doe',
+                'job_title' => 'female nutter'
             ],
         ], $rows);
     }

--- a/tests/SimpleExcelReaderTest.php
+++ b/tests/SimpleExcelReaderTest.php
@@ -284,4 +284,28 @@ class SimpleExcelReaderTest extends TestCase
             ],
         ], $rows);
     }
+
+    /** @test */
+    public function it_can_use_custom_header_row_formatter()
+    {
+        $rows = SimpleExcelReader::create($this->getStubPath('header-and-rows.csv'))
+            ->headerRowFormatter(function($header) {
+                return $header . '_suffix';
+            })
+            ->getRows()
+            ->toArray();
+
+        $this->assertEquals([
+            [
+                'email_suffix' => 'john@example.com',
+                'first_name_suffix' => 'john',
+                'last_name_suffix' => 'doe'
+            ],
+            [
+                'email_suffix' => 'mary-jane@example.com',
+                'first_name_suffix' => 'mary jane',
+                'last_name_suffix' => 'doe'
+            ],
+        ], $rows);
+    }
 }

--- a/tests/stubs/headers-not-snake-case.csv
+++ b/tests/stubs/headers-not-snake-case.csv
@@ -1,0 +1,3 @@
+Email,First Name,Last Name
+john@example.com,john,doe
+mary-jane@example.com,mary jane,doe

--- a/tests/stubs/headers-not-snake-case.csv
+++ b/tests/stubs/headers-not-snake-case.csv
@@ -1,3 +1,3 @@
-Email,First Name,Last Name
-john@example.com,john,doe
-mary-jane@example.com,mary jane,doe
+Email,first name,Last Name, JobTitle
+john@example.com,john,doe,male nutter
+mary-jane@example.com,mary jane,doe,female nutter


### PR DESCRIPTION
This PR adds a new method that allows the conversion of headers to snake_case format.

```csv
Email,First Name,Last Name
john@example.com,john,doe
mary-jane@example.com,mary jane,doe
```

```php
$rows = SimpleExcelReader::create($pathToCsv)
    ->headersToSnakeCase()
    ->getRows()
    ->each(function(array $rowProperties) {
        // rowProperties converted to snake_case
        // ['email' => 'john@example', 'first_name' => 'John', 'last_name' => 'doe']
});
```

Laravel Excel 2 automatically converts all the headers to snake_case and I wanted to keep the same behaviour so users don't have to update any of the import templates. I am currently migrating to Simple Excel as I didn't like the latest version of Laravel Excel (too much boilerplate for simple tasks). Hope this can be helpful for others in the same situation.

