### PR TITLE
Allow all forms of callables to format header

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "box/spout": "^3.0",
         "illuminate/support": "^6.3|^7.0|^8.0"
     },

--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -7,7 +7,6 @@ use Box\Spout\Reader\Common\Creator\ReaderEntityFactory;
 use Box\Spout\Reader\Common\Creator\ReaderFactory;
 use Box\Spout\Reader\IteratorInterface;
 use Box\Spout\Reader\ReaderInterface;
-use Closure;
 use Illuminate\Support\LazyCollection;
 
 class SimpleExcelReader

--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -28,7 +28,7 @@ class SimpleExcelReader
 
     protected ?string $trimHeaderCharacters = null;
 
-    protected ?Closure $formatHeadersUsing = null;
+    protected mixed $formatHeadersUsing = null;
 
     protected ?array $headers = null;
 


### PR DESCRIPTION
At this moment only closures are accepted to format the CSV-headers.

When I was testing locally, I tested this and the example below is perfectly valid:
```php
// Example using the array callable

class FormatHeader
{
  public function format(string $header): string
  {
    return strtolower($header);
  }
}

$postcodes = SimpleExcelReader::create(__DIR__.'/postcodes.csv')
  ->formatHeadersUsing([new FormatHeader, 'format'])
  ->useDelimiter(';')
  ->getRows();
```

To use this kind of variations, the proposed change is needed.

FYI, WordPress support this kind of callables too, without using strongly typing.
Most of the times I use `add_filter('filter_name', [$this, 'method_name'], 10, 1)` when adding filters in WordPress, where the second argument is the callable.
See: https://core.trac.wordpress.org/browser/tags/5.7.1/src/wp-includes/plugin.php#L100

Proof:
- https://www.php.net/manual/en/function.call-user-func.php#refsect1-function.call-user-func-examples
- https://www.php.net/manual/en/language.types.callable.php#118032