### PR TITLE
Implement useEnclosure pass through function.

### DIFF
--- a/src/SimpleExcelWriter.php
+++ b/src/SimpleExcelWriter.php
@@ -155,6 +155,13 @@ class SimpleExcelWriter
 
         return $this;
     }
+    
+    public function useEnclosure(string $enclosure): self
+    {
+        $this->writer->setFieldEnclosure($enclosure);
+
+        return $this;
+    }
 
     public function __destruct()
     {


### PR DESCRIPTION
The SimpleExcelWriter class missed the option to pass through a custom enclosure string. This PR implements the required method