### PR TITLE
Ability to set custom headers (whether or not headers exist in the file)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ $rows = SimpleExcelReader::create($pathToXlsx)
 
 If you would like to retrieve the header row as an array, you can use the `getHeaders()` method.
 
+If you have used `setHeaders()` to set custom headers, these will be returned instead of the actual headers in the file. To get the original headers from the file, use `getOriginalHeaders()`.
+
 ```php
 $headers = SimpleExcelReader::create($pathToCsv)->getHeaders();
 

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ SimpleExcelReader::create($pathToCsv)->getRows()
     });
 ```
 
-#### Reading a file without titles
+#### Reading a file without headers
 
-If the file you are reading does not contain a title row, then you should use the `noHeaderRow()` method.
+If the file you are reading does not contain a header row, then you should use the `noHeaderRow()` method.
 
 ```php
 // $rows is an instance of Illuminate\Support\LazyCollection
@@ -107,6 +107,25 @@ $rows = SimpleExcelReader::create($pathToCsv)
 });
 ```
 
+#### Manually setting the headers
+
+If you would like to use a specific array of values for the headers, you can use the `setHeaders()` method.
+
+```php
+// $rows is an instance of Illuminate\Support\LazyCollection
+$rows = SimpleExcelReader::create($pathToCsv)
+    ->setHeaders(['email_address', 'given_name'])
+    ->getRows()
+    ->each(function(array $rowProperties) {
+       // in the first pass $rowProperties will contain
+       // ['email_address' => 'john@example', 'given_name' => 'john']
+});
+```
+
+If your file already contains a header row, it will be ignored and replaced with your custom headers.
+
+If your file does not contain a header row, you should also use `noHeaderRow()`, and your headers will be used instead of numeric keys, as above.
+
 ### Working with multiple sheet documents
 
 Excel files can include multiple spreadsheets. You can select the sheet you want to use with the `fromSheet()` method.
@@ -117,7 +136,7 @@ $rows = SimpleExcelReader::create($pathToXlsx)
     ->getRows();
 ```
 
-#### Retrieving Header Row values
+#### Retrieving header row values
 
 If you would like to retrieve the header row as an array, you can use the `getHeaders()` method.
 
@@ -162,7 +181,7 @@ $rows = SimpleExcelReader::create($pathToCsv)
 });
 ```
 
-#### Trimming Header Row values
+#### Trimming headers
 
 If the file you are reading contains a title row, but you need to trim additional characters on the title values, then you should use the `trimHeaderRow()` method.
 This functionality mimics the `trim` method, and the default characters it trims, matches that function.

--- a/README.md
+++ b/README.md
@@ -109,12 +109,12 @@ $rows = SimpleExcelReader::create($pathToCsv)
 
 #### Manually setting the headers
 
-If you would like to use a specific array of values for the headers, you can use the `setHeaders()` method.
+If you would like to use a specific array of values for the headers, you can use the `useHeaders()` method.
 
 ```php
 // $rows is an instance of Illuminate\Support\LazyCollection
 $rows = SimpleExcelReader::create($pathToCsv)
-    ->setHeaders(['email_address', 'given_name'])
+    ->useHeaders(['email_address', 'given_name'])
     ->getRows()
     ->each(function(array $rowProperties) {
        // in the first pass $rowProperties will contain
@@ -140,7 +140,7 @@ $rows = SimpleExcelReader::create($pathToXlsx)
 
 If you would like to retrieve the header row as an array, you can use the `getHeaders()` method.
 
-If you have used `setHeaders()` to set custom headers, these will be returned instead of the actual headers in the file. To get the original headers from the file, use `getOriginalHeaders()`.
+If you have used `useHeaders()` to set custom headers, these will be returned instead of the actual headers in the file. To get the original headers from the file, use `getOriginalHeaders()`.
 
 ```php
 $headers = SimpleExcelReader::create($pathToCsv)->getHeaders();

--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -178,12 +178,12 @@ class SimpleExcelReader
 
     public function getHeaders(): ?array
     {
-        if (! $this->processHeader) {
-            return null;
-        }
-
         if ($this->headers) {
             return $this->headers;
+        }
+
+        if (! $this->processHeader) {
+            return null;
         }
 
         $sheet = $this->getSheet();

--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -78,6 +78,13 @@ class SimpleExcelReader
         return $this;
     }
 
+    public function setHeaders(array $headers): self
+    {
+        $this->headers = $headers;
+
+        return $this;
+    }
+
     public function useDelimiter(string $delimiter): self
     {
         $this->reader->setFieldDelimiter($delimiter);
@@ -267,7 +274,7 @@ class SimpleExcelReader
         $values = $row->toArray();
         ksort($values);
 
-        if (! $this->processHeader) {
+        if (! $this->headers) {
             return $values;
         }
 

--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -80,7 +80,7 @@ class SimpleExcelReader
         return $this;
     }
 
-    public function setHeaders(array $headers): self
+    public function useHeaders(array $headers): self
     {
         $this->customHeaders = $headers;
 

--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -223,6 +223,13 @@ class SimpleExcelReader
         return $this->headers;
     }
 
+    public function getOriginalHeaders(): ?array
+    {
+        $this->getHeaders();
+
+        return $this->headers;
+    }
+
     public function close()
     {
         $this->reader->close();

--- a/tests/SimpleExcelReaderTest.php
+++ b/tests/SimpleExcelReaderTest.php
@@ -217,6 +217,35 @@ class SimpleExcelReaderTest extends TestCase
     }
 
     /** @test */
+    public function it_can_retrieve_the_custom_headers_with_headers()
+    {
+        $headers = SimpleExcelReader::create($this->getStubPath('header-and-rows.csv'))
+            ->setHeaders(['email_address', 'given_name', 'surname'])
+            ->getHeaders();
+
+        $this->assertEquals([
+            0 => 'email_address',
+            1 => 'given_name',
+            2 => 'surname',
+        ], $headers);
+    }
+
+    /** @test */
+    public function it_can_retrieve_the_custom_headers_without_headers()
+    {
+        $headers = SimpleExcelReader::create($this->getStubPath('rows-without-header.csv'))
+            ->noHeaderRow()
+            ->setHeaders(['email_address', 'given_name', 'surname'])
+            ->getHeaders();
+
+        $this->assertEquals([
+            0 => 'email_address',
+            1 => 'given_name',
+            2 => 'surname',
+        ], $headers);
+    }
+
+    /** @test */
     public function it_can_use_an_alternative_delimiter()
     {
         $rows = SimpleExcelReader::create($this->getStubPath('alternative-delimiter.csv'))

--- a/tests/SimpleExcelReaderTest.php
+++ b/tests/SimpleExcelReaderTest.php
@@ -172,11 +172,11 @@ class SimpleExcelReaderTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_custom_headers_without_header()
+    public function it_can_use_custom_headers_without_header()
     {
         $rows = SimpleExcelReader::create($this->getStubPath('rows-without-header.csv'))
             ->noHeaderRow()
-            ->setHeaders(['email', 'first_name', 'last_name'])
+            ->useHeaders(['email', 'first_name', 'last_name'])
             ->getRows()
             ->toArray();
 
@@ -195,10 +195,10 @@ class SimpleExcelReaderTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_custom_headers_with_header()
+    public function it_can_use_custom_headers_with_header()
     {
         $rows = SimpleExcelReader::create($this->getStubPath('header-and-rows.csv'))
-            ->setHeaders(['email_address', 'given_name', 'surname'])
+            ->useHeaders(['email_address', 'given_name', 'surname'])
             ->getRows()
             ->toArray();
 
@@ -217,11 +217,11 @@ class SimpleExcelReaderTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_custom_headers_with_header_on_row()
+    public function it_can_use_custom_headers_with_header_on_row()
     {
         $rows = SimpleExcelReader::create($this->getStubPath('header-not-on-first-row.xlsx'))
             ->headerOnRow(2)
-            ->setHeaders(['first_name', 'last_name'])
+            ->useHeaders(['first_name', 'last_name'])
             ->getRows()
             ->toArray();
 
@@ -241,7 +241,7 @@ class SimpleExcelReaderTest extends TestCase
     public function it_can_retrieve_the_custom_headers_with_headers()
     {
         $headers = SimpleExcelReader::create($this->getStubPath('header-and-rows.csv'))
-            ->setHeaders(['email_address', 'given_name', 'surname'])
+            ->useHeaders(['email_address', 'given_name', 'surname'])
             ->getHeaders();
 
         $this->assertEquals([
@@ -256,7 +256,7 @@ class SimpleExcelReaderTest extends TestCase
     {
         $headers = SimpleExcelReader::create($this->getStubPath('rows-without-header.csv'))
             ->noHeaderRow()
-            ->setHeaders(['email_address', 'given_name', 'surname'])
+            ->useHeaders(['email_address', 'given_name', 'surname'])
             ->getHeaders();
 
         $this->assertEquals([
@@ -270,7 +270,7 @@ class SimpleExcelReaderTest extends TestCase
     public function it_can_retrieve_the_original_headers_with_custom_headers()
     {
         $reader = SimpleExcelReader::create($this->getStubPath('header-and-rows.csv'))
-            ->setHeaders(['email_address', 'given_name', 'surname']);
+            ->useHeaders(['email_address', 'given_name', 'surname']);
 
         $headers = $reader->getHeaders();
         $originalHeaders = $reader->getOriginalHeaders();

--- a/tests/SimpleExcelReaderTest.php
+++ b/tests/SimpleExcelReaderTest.php
@@ -172,6 +172,51 @@ class SimpleExcelReaderTest extends TestCase
     }
 
     /** @test */
+    public function it_can_set_custom_headers_without_header()
+    {
+        $rows = SimpleExcelReader::create($this->getStubPath('rows-without-header.csv'))
+            ->noHeaderRow()
+            ->setHeaders(['email', 'first_name', 'last_name'])
+            ->getRows()
+            ->toArray();
+
+        $this->assertEquals([
+            [
+                'email' => 'john@example.com',
+                'first_name' => 'john',
+                'last_name' => 'doe',
+            ],
+            [
+                'email' => 'mary-jane@example.com',
+                'first_name' => 'mary jane',
+                'last_name' => 'doe',
+            ],
+        ], $rows);
+    }
+
+    /** @test */
+    public function it_can_set_custom_headers_with_header()
+    {
+        $rows = SimpleExcelReader::create($this->getStubPath('header-and-rows.csv'))
+            ->setHeaders(['email_address', 'given_name', 'surname'])
+            ->getRows()
+            ->toArray();
+
+        $this->assertEquals([
+            [
+                'email_address' => 'john@example.com',
+                'given_name' => 'john',
+                'surname' => 'doe',
+            ],
+            [
+                'email_address' => 'mary-jane@example.com',
+                'given_name' => 'mary jane',
+                'surname' => 'doe',
+            ],
+        ], $rows);
+    }
+
+    /** @test */
     public function it_can_use_an_alternative_delimiter()
     {
         $rows = SimpleExcelReader::create($this->getStubPath('alternative-delimiter.csv'))

--- a/tests/SimpleExcelReaderTest.php
+++ b/tests/SimpleExcelReaderTest.php
@@ -267,6 +267,28 @@ class SimpleExcelReaderTest extends TestCase
     }
 
     /** @test */
+    public function it_can_retrieve_the_original_headers_with_custom_headers()
+    {
+        $reader = SimpleExcelReader::create($this->getStubPath('header-and-rows.csv'))
+            ->setHeaders(['email_address', 'given_name', 'surname']);
+
+        $headers = $reader->getHeaders();
+        $originalHeaders = $reader->getOriginalHeaders();
+
+        $this->assertEquals([
+            0 => 'email_address',
+            1 => 'given_name',
+            2 => 'surname',
+        ], $headers);
+
+        $this->assertEquals([
+            0 => 'email',
+            1 => 'first_name',
+            2 => 'last_name',
+        ], $originalHeaders);
+    }
+
+    /** @test */
     public function it_can_use_an_alternative_delimiter()
     {
         $rows = SimpleExcelReader::create($this->getStubPath('alternative-delimiter.csv'))

--- a/tests/SimpleExcelReaderTest.php
+++ b/tests/SimpleExcelReaderTest.php
@@ -217,6 +217,27 @@ class SimpleExcelReaderTest extends TestCase
     }
 
     /** @test */
+    public function it_can_set_custom_headers_with_header_on_row()
+    {
+        $rows = SimpleExcelReader::create($this->getStubPath('header-not-on-first-row.xlsx'))
+            ->headerOnRow(2)
+            ->setHeaders(['first_name', 'last_name'])
+            ->getRows()
+            ->toArray();
+
+        $this->assertEquals([
+            [
+                'first_name' => 'Taylor',
+                'last_name' => 'Otwell',
+            ],
+            [
+                'first_name' => 'Adam',
+                'last_name' => 'Wathan',
+            ],
+        ], $rows);
+    }
+
+    /** @test */
     public function it_can_retrieve_the_custom_headers_with_headers()
     {
         $headers = SimpleExcelReader::create($this->getStubPath('header-and-rows.csv'))

--- a/tests/stubs/rows-without-header.csv
+++ b/tests/stubs/rows-without-header.csv
@@ -1,0 +1,2 @@
+john@example.com,john,doe
+mary-jane@example.com,mary jane,doe


### PR DESCRIPTION
If you read a CSV file which does not contain a header row, you will use `noHeaderRow()`, which returns each data row with integer keys.

For example, this file:

```csv
john@example.com,john,doe
mary-jane@example.com,mary jane,doe
```
will be returned as:
```php
[
    [
        0 => 'john@example.com',
        1 => 'john',
        2 => 'doe',
    ],
    [
        0 => 'mary-jane@example.com',
        1 => 'mary jane',
        2 => 'doe',
    ],
]
```

However, if you already know what the headers should be for the file (i.e. they are defined externally), it would be nice to be able to get each data row with the correct headers.

For example, you know the headers should be `email`, `first_name` and `last_name`, so you want the above file to be returned as:
```php
[
    [
        'email' => 'john@example.com',
        'first_name' => 'john',
        'last_name' => 'doe',
    ],
    [
        'email' => 'mary-jane@example.com',
        'first_name' => 'mary jane',
        'last_name' => 'doe',
    ],
]
```

In order to do this currently, you would need to reimplement all the array_slice/array_combine logic from `getValueFromRow()` in your own code.

To support this, I have added a `setHeaders(array $headers)` method, where you can specify the custom headers to use. It affects the output of `getValueFromRow()` and therefore `getRows()`, so that the custom headers are used instead of integer keys.

It can either be used with `noHeaderRow()` (custom headers will be used instead of integer keys), or without (custom headers will be used instead of the headers defined in the file, and the header row will not be returned as a data row). It is also compatible with `headerOnRow()` (previous rows will be skipped, and custom headers will be used instead of headers defined in the file).

It also affects the output of `getHeaders()` by returning only the custom headers you have defined, so the new `getOriginalHeaders()` method can be used to get the header row actually defined in the file, if required.