### PR TITLE
Add optional styling when adding multiple rows to xslx

### DIFF
--- a/src/SimpleExcelWriter.php
+++ b/src/SimpleExcelWriter.php
@@ -118,10 +118,10 @@ class SimpleExcelWriter
         return $this;
     }
 
-    public function addRows(iterable $rows)
+    public function addRows(iterable $rows, Style $style = null)
     {
         foreach ($rows as $row) {
-            $this->addRow($row);
+            $this->addRow($row, $style);
         }
 
         return $this;


### PR DESCRIPTION
Adds an optional, nullable style parameter to the addRows method to allow applying styles to all the rows in the collection.  Brings parity with the singular addRow method since addRows just defers to it anyway.