### PR TITLE
Added addHeaderFromArray method to the SimpleWriter

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ John,Doe
 Jane,Doe
 ```
 
-#### Or manually set the header from aarray
+#### Or manually set the header from array
 ```php
 use Spatie\SimpleExcel\SimpleExcelWriter;
 

--- a/README.md
+++ b/README.md
@@ -311,7 +311,10 @@ John,Doe
 Jane,Doe
 ```
 
-#### Or manually set the header from array
+#### Manually set the header from array
+
+Instead of automatically let the package dedecting a header row, you can set it manually.
+
 ```php
 use Spatie\SimpleExcel\SimpleExcelWriter;
 

--- a/README.md
+++ b/README.md
@@ -311,6 +311,16 @@ John,Doe
 Jane,Doe
 ```
 
+#### Or manually set the header from aarray
+```php
+use Spatie\SimpleExcel\SimpleExcelWriter;
+
+$writer = SimpleExcelWriter::create($pathToCsv)
+    ->addHeader(['first_name', 'last_name'])
+    ->addRow(['John', 'Doe'])
+    ->addRow(['Jane', 'Doe'])
+```
+
 #### Writing an Excel file
 
 Writing an Excel file is identical to writing a csv. Just make sure that the path given to the `create` method of `SimpleExcelWriter` ends with `xlsx`.

--- a/src/SimpleExcelWriter.php
+++ b/src/SimpleExcelWriter.php
@@ -127,7 +127,7 @@ class SimpleExcelWriter
         return $this;
     }
 
-    public function addHeaderFromArray(array $header): self
+    public function addHeader(array $header): self
     {
         $headerRow = WriterEntityFactory::createRowFromArray($header, $this->headerStyle);
 

--- a/src/SimpleExcelWriter.php
+++ b/src/SimpleExcelWriter.php
@@ -26,7 +26,7 @@ class SimpleExcelWriter
 
         $writer = $simpleExcelWriter->getWriter();
 
-        if ( $configureWriter ) {
+        if ($configureWriter) {
             $configureWriter($writer);
         }
 
@@ -37,7 +37,7 @@ class SimpleExcelWriter
 
     public static function createWithoutBom(string $file, string $type = '')
     {
-        return static::create($file, $type, fn($writer) => $writer->setShouldAddBOM(false));
+        return static::create($file, $type, fn ($writer) => $writer->setShouldAddBOM(false));
     }
 
     public static function streamDownload(string $downloadName, string $type = '', callable $writerCallback = null)
@@ -46,7 +46,7 @@ class SimpleExcelWriter
 
         $writer = $simpleExcelWriter->getWriter();
 
-        if ( $writerCallback ) {
+        if ($writerCallback) {
             $writerCallback($writer);
         }
 
@@ -87,7 +87,7 @@ class SimpleExcelWriter
     }
 
     /**
-     * @param \Box\Spout\Common\Entity\Style\Style $style
+     *  @param \Box\Spout\Common\Entity\Style\Style $style
      */
     public function setHeaderStyle($style)
     {
@@ -102,8 +102,8 @@ class SimpleExcelWriter
      */
     public function addRow($row, Style $style = null)
     {
-        if ( is_array($row) ) {
-            if ( $this->processHeader && $this->processingFirstRow ) {
+        if (is_array($row)) {
+            if ($this->processHeader && $this->processingFirstRow) {
                 $this->writeHeaderFromRow($row);
             }
 
@@ -111,18 +111,6 @@ class SimpleExcelWriter
         }
 
         $this->writer->addRow($row);
-        $this->numberOfRows++;
-
-        $this->processingFirstRow = false;
-
-        return $this;
-    }
-
-    public function addHeaderFromArray(array $header)
-    {
-        $headerRow = WriterEntityFactory::createRowFromArray($header, $this->headerStyle);
-
-        $this->writer->addRow($headerRow);
         $this->numberOfRows++;
 
         $this->processingFirstRow = false;
@@ -139,7 +127,19 @@ class SimpleExcelWriter
         return $this;
     }
 
-    protected function writeHeaderFromRow(array $row): self
+    public function addHeaderFromArray(array $header): self
+    {
+        $headerRow = WriterEntityFactory::createRowFromArray($header, $this->headerStyle);
+
+        $this->writer->addRow($headerRow);
+        $this->numberOfRows++;
+
+        $this->processingFirstRow = false;
+
+        return $this;
+    }
+
+    protected function writeHeaderFromRow(array $row)
     {
         $headerValues = array_keys($row);
 
@@ -152,7 +152,7 @@ class SimpleExcelWriter
     /**
      * Add a new sheet to the workbook.
      *
-     * @param string|null $name The name of the sheet. If null, the name will be "SheetX" where X is the sheet index.
+     * @param  string|null  $name The name of the sheet. If null, the name will be "SheetX" where X is the sheet index.
      *
      * @return $this
      */
@@ -160,7 +160,7 @@ class SimpleExcelWriter
     {
         $this->writer->addNewSheetAndMakeItCurrent();
         $this->processingFirstRow = true;
-        if ( $name ) {
+        if ($name) {
             $this->nameCurrentSheet($name);
         }
 
@@ -170,7 +170,7 @@ class SimpleExcelWriter
     /**
      * Sets the name for the current sheet.
      *
-     * @param string $name
+     * @param  string  $name
      *
      * @return $this
      */

--- a/src/SimpleExcelWriter.php
+++ b/src/SimpleExcelWriter.php
@@ -26,7 +26,7 @@ class SimpleExcelWriter
 
         $writer = $simpleExcelWriter->getWriter();
 
-        if ($configureWriter) {
+        if ( $configureWriter ) {
             $configureWriter($writer);
         }
 
@@ -37,7 +37,7 @@ class SimpleExcelWriter
 
     public static function createWithoutBom(string $file, string $type = '')
     {
-        return static::create($file, $type, fn ($writer) => $writer->setShouldAddBOM(false));
+        return static::create($file, $type, fn($writer) => $writer->setShouldAddBOM(false));
     }
 
     public static function streamDownload(string $downloadName, string $type = '', callable $writerCallback = null)
@@ -46,7 +46,7 @@ class SimpleExcelWriter
 
         $writer = $simpleExcelWriter->getWriter();
 
-        if ($writerCallback) {
+        if ( $writerCallback ) {
             $writerCallback($writer);
         }
 
@@ -59,8 +59,10 @@ class SimpleExcelWriter
     {
         $this->path = $path;
 
-        $this->writer = $type ?
-            WriterEntityFactory::createWriter($type) :
+        $this->writer = $type
+            ?
+            WriterEntityFactory::createWriter($type)
+            :
             WriterEntityFactory::createWriterFromFile($this->path);
     }
 
@@ -87,7 +89,7 @@ class SimpleExcelWriter
     }
 
     /**
-     *  @param \Box\Spout\Common\Entity\Style\Style $style
+     * @param \Box\Spout\Common\Entity\Style\Style $style
      */
     public function setHeaderStyle($style)
     {
@@ -97,13 +99,13 @@ class SimpleExcelWriter
     }
 
     /**
-     * @param \Box\Spout\Common\Entity\Row|array $row
+     * @param \Box\Spout\Common\Entity\Row|array        $row
      * @param \Box\Spout\Common\Entity\Style\Style|null $style
      */
     public function addRow($row, Style $style = null)
     {
-        if (is_array($row)) {
-            if ($this->processHeader && $this->processingFirstRow) {
+        if ( is_array($row) ) {
+            if ( $this->processHeader && $this->processingFirstRow ) {
                 $this->writeHeaderFromRow($row);
             }
 
@@ -111,6 +113,18 @@ class SimpleExcelWriter
         }
 
         $this->writer->addRow($row);
+        $this->numberOfRows++;
+
+        $this->processingFirstRow = false;
+
+        return $this;
+    }
+
+    public function addHeaderFromArray(array $header)
+    {
+        $headerRow = WriterEntityFactory::createRowFromArray($header, $this->headerStyle);
+
+        $this->writer->addRow($headerRow);
         $this->numberOfRows++;
 
         $this->processingFirstRow = false;
@@ -140,7 +154,7 @@ class SimpleExcelWriter
     /**
      * Add a new sheet to the workbook.
      *
-     * @param  string|null  $name The name of the sheet. If null, the name will be "SheetX" where X is the sheet index.
+     * @param string|null $name The name of the sheet. If null, the name will be "SheetX" where X is the sheet index.
      *
      * @return $this
      */
@@ -148,7 +162,7 @@ class SimpleExcelWriter
     {
         $this->writer->addNewSheetAndMakeItCurrent();
         $this->processingFirstRow = true;
-        if ($name) {
+        if ( $name ) {
             $this->nameCurrentSheet($name);
         }
 
@@ -158,7 +172,7 @@ class SimpleExcelWriter
     /**
      * Sets the name for the current sheet.
      *
-     * @param  string  $name
+     * @param string $name
      *
      * @return $this
      */

--- a/src/SimpleExcelWriter.php
+++ b/src/SimpleExcelWriter.php
@@ -59,10 +59,8 @@ class SimpleExcelWriter
     {
         $this->path = $path;
 
-        $this->writer = $type
-            ?
-            WriterEntityFactory::createWriter($type)
-            :
+        $this->writer = $type ?
+            WriterEntityFactory::createWriter($type) :
             WriterEntityFactory::createWriterFromFile($this->path);
     }
 
@@ -99,7 +97,7 @@ class SimpleExcelWriter
     }
 
     /**
-     * @param \Box\Spout\Common\Entity\Row|array        $row
+     * @param \Box\Spout\Common\Entity\Row|array $row
      * @param \Box\Spout\Common\Entity\Style\Style|null $style
      */
     public function addRow($row, Style $style = null)
@@ -141,7 +139,7 @@ class SimpleExcelWriter
         return $this;
     }
 
-    protected function writeHeaderFromRow(array $row)
+    protected function writeHeaderFromRow(array $row): self
     {
         $headerValues = array_keys($row);
 

--- a/tests/SimpleExcelWriterTest.php
+++ b/tests/SimpleExcelWriterTest.php
@@ -62,7 +62,7 @@ it('can use an alternative delimiter', function () {
 
 it('can write the header from array', function () {
     $writerWithAutomaticHeader = SimpleExcelWriter::create($this->pathToCsv)
-        ->addHeaderFromArray(['first_name', 'last_name'])
+        ->addHeader(['first_name', 'last_name'])
         ->addRow(['John', 'Doe']);
 
     expect($writerWithAutomaticHeader->getNumberOfRows())->toEqual(2);

--- a/tests/SimpleExcelWriterTest.php
+++ b/tests/SimpleExcelWriterTest.php
@@ -2,14 +2,13 @@
 
 use OpenSpout\Writer\CSV\Writer;
 use Spatie\SimpleExcel\SimpleExcelWriter;
+use Spatie\TemporaryDirectory\TemporaryDirectory;
 use function Spatie\Snapshots\assertMatchesFileSnapshot;
 
-use Spatie\TemporaryDirectory\TemporaryDirectory;
-
 beforeEach(function () {
-    $this->temporaryDirectory = new TemporaryDirectory(__DIR__ . '/temp');
+    $this->temporaryDirectory = new TemporaryDirectory(__DIR__.'/temp');
 
-    $this->pathToCsv = $this->temporaryDirectory->path('test.csv');
+    $this->pathToCsv  = $this->temporaryDirectory->path('test.csv');
     $this->pathToXlsx = $this->temporaryDirectory->path('test.xlsx');
 });
 
@@ -17,11 +16,11 @@ it('can write a regular CSV', function () {
     SimpleExcelWriter::create($this->pathToCsv)
         ->addRow([
             'first_name' => 'John',
-            'last_name' => 'Doe',
+            'last_name'  => 'Doe',
         ])
         ->addRow([
             'first_name' => 'Jane',
-            'last_name' => 'Doe',
+            'last_name'  => 'Doe',
         ]);
 
     assertMatchesFileSnapshot($this->pathToCsv);
@@ -33,11 +32,11 @@ test('add multiple rows', function () {
             [
                 [
                     'first_name' => 'John',
-                    'last_name' => 'Doe',
+                    'last_name'  => 'Doe',
                 ],
                 [
                     'first_name' => 'Jane',
-                    'last_name' => 'Doe',
+                    'last_name'  => 'Doe',
                 ],
             ]
         );
@@ -50,11 +49,11 @@ it('can use an alternative delimiter', function () {
         ->useDelimiter(';')
         ->addRow([
             'first_name' => 'John',
-            'last_name' => 'Doe',
+            'last_name'  => 'Doe',
         ])
         ->addRow([
             'first_name' => 'Jane',
-            'last_name' => 'Doe',
+            'last_name'  => 'Doe',
         ]);
 
     assertMatchesFileSnapshot($this->pathToCsv);
@@ -65,12 +64,22 @@ it('can write a CSV without a header', function () {
         ->noHeaderRow()
         ->addRow([
             'first_name' => 'John',
-            'last_name' => 'Doe',
+            'last_name'  => 'Doe',
         ])
         ->addRow([
             'first_name' => 'Jane',
-            'last_name' => 'Doe',
+            'last_name'  => 'Doe',
         ]);
+
+    assertMatchesFileSnapshot($this->pathToCsv);
+});
+
+it('can write the header from array', function () {
+    $writerWithAutomaticHeader = SimpleExcelWriter::create($this->pathToCsv)
+        ->addHeaderFromArray(['first_name', 'last_name'])
+        ->addRow(['John', 'Doe']);
+
+    expect($writerWithAutomaticHeader->getNumberOfRows())->toEqual(2);
 
     assertMatchesFileSnapshot($this->pathToCsv);
 });
@@ -79,7 +88,7 @@ it('can get the number of rows written', function () {
     $writerWithAutomaticHeader = SimpleExcelWriter::create($this->pathToCsv)
         ->addRow([
             'first_name' => 'John',
-            'last_name' => 'Doe',
+            'last_name'  => 'Doe',
         ]);
 
     expect($writerWithAutomaticHeader->getNumberOfRows())->toEqual(2);
@@ -88,7 +97,7 @@ it('can get the number of rows written', function () {
         ->noHeaderRow()
         ->addRow([
             'first_name' => 'John',
-            'last_name' => 'Doe',
+            'last_name'  => 'Doe',
         ]);
 
     expect($writerWithoutAutomaticHeader->getNumberOfRows())->toEqual(1);
@@ -110,7 +119,7 @@ it('can write a CSV without bom', function () {
     $writer = SimpleExcelWriter::createWithoutBom($this->pathToCsv)
         ->addRow([
             'first_name' => 'Jane',
-            'last_name' => 'Doe',
+            'last_name'  => 'Doe',
         ]);
 
     assertMatchesFileSnapshot($this->pathToCsv);
@@ -118,14 +127,14 @@ it('can write a CSV without bom', function () {
 
 it('can name a xlsx sheet', function () {
     $writer = SimpleExcelWriter::create($this->pathToXlsx)
-                               ->nameCurrentSheet('TestSheet');
+        ->nameCurrentSheet('TestSheet');
 
     expect($writer->getWriter()->getCurrentSheet()->getName())->toEqual('TestSheet');
 });
 
 it('can add a xlsx sheet', function () {
     $writer = SimpleExcelWriter::create($this->pathToXlsx)
-                               ->addNewSheetAndMakeItCurrent();
+        ->addNewSheetAndMakeItCurrent();
 
     expect(count($writer->getWriter()->getSheets()))->toEqual(2);
     expect($writer->getWriter()->getCurrentSheet()->getName())->toEqual('Sheet2');
@@ -133,7 +142,7 @@ it('can add a xlsx sheet', function () {
 
 it('can add and name a xlsx sheet', function () {
     $writer = SimpleExcelWriter::create($this->pathToXlsx)
-                               ->addNewSheetAndMakeItCurrent('TestSheet');
+        ->addNewSheetAndMakeItCurrent('TestSheet');
 
     expect(count($writer->getWriter()->getSheets()))->toEqual(2);
     expect($writer->getWriter()->getCurrentSheet()->getName())->toEqual('TestSheet');

--- a/tests/SimpleExcelWriterTest.php
+++ b/tests/SimpleExcelWriterTest.php
@@ -2,13 +2,14 @@
 
 use OpenSpout\Writer\CSV\Writer;
 use Spatie\SimpleExcel\SimpleExcelWriter;
-use Spatie\TemporaryDirectory\TemporaryDirectory;
 use function Spatie\Snapshots\assertMatchesFileSnapshot;
 
-beforeEach(function () {
-    $this->temporaryDirectory = new TemporaryDirectory(__DIR__.'/temp');
+use Spatie\TemporaryDirectory\TemporaryDirectory;
 
-    $this->pathToCsv  = $this->temporaryDirectory->path('test.csv');
+beforeEach(function () {
+    $this->temporaryDirectory = new TemporaryDirectory(__DIR__ . '/temp');
+
+    $this->pathToCsv = $this->temporaryDirectory->path('test.csv');
     $this->pathToXlsx = $this->temporaryDirectory->path('test.xlsx');
 });
 
@@ -16,11 +17,11 @@ it('can write a regular CSV', function () {
     SimpleExcelWriter::create($this->pathToCsv)
         ->addRow([
             'first_name' => 'John',
-            'last_name'  => 'Doe',
+            'last_name' => 'Doe',
         ])
         ->addRow([
             'first_name' => 'Jane',
-            'last_name'  => 'Doe',
+            'last_name' => 'Doe',
         ]);
 
     assertMatchesFileSnapshot($this->pathToCsv);
@@ -32,11 +33,11 @@ test('add multiple rows', function () {
             [
                 [
                     'first_name' => 'John',
-                    'last_name'  => 'Doe',
+                    'last_name' => 'Doe',
                 ],
                 [
                     'first_name' => 'Jane',
-                    'last_name'  => 'Doe',
+                    'last_name' => 'Doe',
                 ],
             ]
         );
@@ -49,26 +50,11 @@ it('can use an alternative delimiter', function () {
         ->useDelimiter(';')
         ->addRow([
             'first_name' => 'John',
-            'last_name'  => 'Doe',
+            'last_name' => 'Doe',
         ])
         ->addRow([
             'first_name' => 'Jane',
-            'last_name'  => 'Doe',
-        ]);
-
-    assertMatchesFileSnapshot($this->pathToCsv);
-});
-
-it('can write a CSV without a header', function () {
-    SimpleExcelWriter::create($this->pathToCsv)
-        ->noHeaderRow()
-        ->addRow([
-            'first_name' => 'John',
-            'last_name'  => 'Doe',
-        ])
-        ->addRow([
-            'first_name' => 'Jane',
-            'last_name'  => 'Doe',
+            'last_name' => 'Doe',
         ]);
 
     assertMatchesFileSnapshot($this->pathToCsv);
@@ -84,11 +70,26 @@ it('can write the header from array', function () {
     assertMatchesFileSnapshot($this->pathToCsv);
 });
 
+it('can write a CSV without a header', function () {
+    SimpleExcelWriter::create($this->pathToCsv)
+        ->noHeaderRow()
+        ->addRow([
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+        ])
+        ->addRow([
+            'first_name' => 'Jane',
+            'last_name' => 'Doe',
+        ]);
+
+    assertMatchesFileSnapshot($this->pathToCsv);
+});
+
 it('can get the number of rows written', function () {
     $writerWithAutomaticHeader = SimpleExcelWriter::create($this->pathToCsv)
         ->addRow([
             'first_name' => 'John',
-            'last_name'  => 'Doe',
+            'last_name' => 'Doe',
         ]);
 
     expect($writerWithAutomaticHeader->getNumberOfRows())->toEqual(2);
@@ -97,7 +98,7 @@ it('can get the number of rows written', function () {
         ->noHeaderRow()
         ->addRow([
             'first_name' => 'John',
-            'last_name'  => 'Doe',
+            'last_name' => 'Doe',
         ]);
 
     expect($writerWithoutAutomaticHeader->getNumberOfRows())->toEqual(1);
@@ -119,7 +120,7 @@ it('can write a CSV without bom', function () {
     $writer = SimpleExcelWriter::createWithoutBom($this->pathToCsv)
         ->addRow([
             'first_name' => 'Jane',
-            'last_name'  => 'Doe',
+            'last_name' => 'Doe',
         ]);
 
     assertMatchesFileSnapshot($this->pathToCsv);
@@ -127,14 +128,14 @@ it('can write a CSV without bom', function () {
 
 it('can name a xlsx sheet', function () {
     $writer = SimpleExcelWriter::create($this->pathToXlsx)
-        ->nameCurrentSheet('TestSheet');
+                               ->nameCurrentSheet('TestSheet');
 
     expect($writer->getWriter()->getCurrentSheet()->getName())->toEqual('TestSheet');
 });
 
 it('can add a xlsx sheet', function () {
     $writer = SimpleExcelWriter::create($this->pathToXlsx)
-        ->addNewSheetAndMakeItCurrent();
+                               ->addNewSheetAndMakeItCurrent();
 
     expect(count($writer->getWriter()->getSheets()))->toEqual(2);
     expect($writer->getWriter()->getCurrentSheet()->getName())->toEqual('Sheet2');
@@ -142,7 +143,7 @@ it('can add a xlsx sheet', function () {
 
 it('can add and name a xlsx sheet', function () {
     $writer = SimpleExcelWriter::create($this->pathToXlsx)
-        ->addNewSheetAndMakeItCurrent('TestSheet');
+                               ->addNewSheetAndMakeItCurrent('TestSheet');
 
     expect(count($writer->getWriter()->getSheets()))->toEqual(2);
     expect($writer->getWriter()->getCurrentSheet()->getName())->toEqual('TestSheet');


### PR DESCRIPTION
Currently, no feature to directly add headers from the array. This PR adds `addHeaderFromArray` method to the SimpleWriter, which allows to add headers from array.