### PR TITLE
V4 with PHP 8.2 support

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -8,22 +8,14 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v1
+                uses: actions/checkout@v3
 
-            -   name: Fix style
+            -   name: Run PHP CS Fixer
                 uses: docker://oskarstark/php-cs-fixer-ga
                 with:
                     args: --config=.php-cs-fixer.dist.php --allow-risky=yes
 
-            -   name: Extract branch name
-                shell: bash
-                run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-                id: extract_branch
-
             -   name: Commit changes
-                uses: stefanzweifel/git-auto-commit-action@v2.3.0
+                uses: stefanzweifel/git-auto-commit-action@v4
                 with:
                     commit_message: Fix styling
-                    branch: ${{ steps.extract_branch.outputs.branch }}
-                env:
-                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -16,7 +16,7 @@ $finder = Symfony\Component\Finder\Finder::create()
 
 return (new PhpCsFixer\Config())
     ->setRules([
-        '@PSR2' => true,
+        '@PSR12' => true,
         'array_syntax' => ['syntax' => 'short'],
         'ordered_imports' => ['sort_algorithm' => 'alpha'],
         'no_unused_imports' => true,

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -13,14 +13,30 @@
 - `\Box\Spout\Common\Entity\Row` should be replaced with `\OpenSpout\Common\Entity\Row`
 - `\Box\Spout\Common\Entity\Style\Style` should be replaced with `OpenSpout\Common\Entity\Style\Style`
 
+### Remove `useDelimiter()`
+
+In v3 there was a method to set a delimiter. Now you should pass this as parameter.
+
+Change
+```php
+$reader = SimpleExcelWriter::create($file)->useDelimiter(';');
+```
+
+To
+```php
+ $writer = SimpleExcelWriter::create(file: $file, delimiter: ';');
+```
+
 ### Drop support for setting the type manually
 
 In v3 of this package it was possible to explicitly set the type. From now in this is not possible anymore
 
+Change
 ```php
 $reader = SimpleExcelReader::create('php://input', 'csv');
 ```
 
+To
 ```php
  $writer = SimpleExcelWriter::create('php://output', 'csv');
 ```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,26 @@
+# Upgrade guide
+
+## Upgrading from 3.x to 4.0
+
+
+### Most notable changes
+
+1. Add support for openspout/openspout v4
+2. Drop support for openspout/openspout v3
+
+### Classes have been moved
+
+- `\Box\Spout\Common\Entity\Row` should be replaced with `\OpenSpout\Common\Entity\Row`
+- `\Box\Spout\Common\Entity\Style\Style` should be replaced with `OpenSpout\Common\Entity\Style\Style`
+
+### Drop support for setting the type manually
+
+In v3 of this package it was possible to explicitly set the type. From now in this is not possible anymore
+
+```php
+$reader = SimpleExcelReader::create('php://input', 'csv');
+```
+
+```php
+ $writer = SimpleExcelWriter::create('php://output', 'csv');
+```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,13 +8,15 @@
 1. Add support for openspout/openspout v4
 2. Drop support for openspout/openspout v3
 3. Add type hinting
+4. Removed `useDelimiter` on SimpleExcelWriter
+5. Removed `headerRowFormatter` on SimpleExcelReader
 
 ### Classes have been moved
 
 - `\Box\Spout\Common\Entity\Row` should be replaced with `\OpenSpout\Common\Entity\Row`
 - `\Box\Spout\Common\Entity\Style\Style` should be replaced with `OpenSpout\Common\Entity\Style\Style`
 
-### Remove `useDelimiter()` on SimpleExcelWriter
+### Removed `useDelimiter()` on SimpleExcelWriter
 
 In v3 there was a method to set a delimiter. Now you should pass this as parameter to the constructor.
 
@@ -28,7 +30,7 @@ To
  $writer = SimpleExcelWriter::create(file: $file, delimiter: ';');
 ```
 
-### Deprecate setting the type manually
+### Deprecated setting the type manually
 
 In v4 of openspout/openspout it is no longer possible to explicitly set the type.
 We still have support for this, but we'll deprecate the method.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -27,16 +27,15 @@ To
  $writer = SimpleExcelWriter::create(file: $file, delimiter: ';');
 ```
 
-### Drop support for setting the type manually
+### Deprecate setting the type manually
 
-In v3 of this package it was possible to explicitly set the type. From now in this is not possible anymore
+In v4 of openspout/openspout it is no longer possible to explicitly set the type.
+We still have support for this, but we'll deprecate the method.
 
-Change
 ```php
 $reader = SimpleExcelReader::create('php://input', 'csv');
 ```
 
-To
 ```php
  $writer = SimpleExcelWriter::create('php://output', 'csv');
 ```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -29,16 +29,3 @@ To
 ```php
  $writer = SimpleExcelWriter::create(file: $file, delimiter: ';');
 ```
-
-### Deprecated setting the type manually
-
-In v4 of openspout/openspout it is no longer possible to explicitly set the type.
-We still have support for this, but we'll deprecate the method.
-
-```php
-$reader = SimpleExcelReader::create('php://input', 'csv');
-```
-
-```php
- $writer = SimpleExcelWriter::create('php://output', 'csv');
-```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -29,3 +29,16 @@ To
 ```php
  $writer = SimpleExcelWriter::create(file: $file, delimiter: ';');
 ```
+
+### Deprecated setting the type manually
+
+In v4 of openspout/openspout it is no longer possible to explicitly set the type.
+We still have support for this, but we'll deprecate the method.
+
+```php
+$reader = SimpleExcelReader::create('php://input', 'csv');
+```
+
+```php
+ $writer = SimpleExcelWriter::create('php://output', 'csv');
+```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,6 @@
 # Upgrade guide
 
-## Upgrading from 3.x to 4.0
+## Upgrading from 2.x to 3.0
 
 
 ### Most notable changes

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,15 +7,16 @@
 
 1. Add support for openspout/openspout v4
 2. Drop support for openspout/openspout v3
+3. Add type hinting
 
 ### Classes have been moved
 
 - `\Box\Spout\Common\Entity\Row` should be replaced with `\OpenSpout\Common\Entity\Row`
 - `\Box\Spout\Common\Entity\Style\Style` should be replaced with `OpenSpout\Common\Entity\Style\Style`
 
-### Remove `useDelimiter()`
+### Remove `useDelimiter()` on SimpleExcelWriter
 
-In v3 there was a method to set a delimiter. Now you should pass this as parameter.
+In v3 there was a method to set a delimiter. Now you should pass this as parameter to the constructor.
 
 Change
 ```php

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "openspout/openspout": "^3.0",
+        "openspout/openspout": "^3.0|^4.0",
         "illuminate/support": "^8.71|^9.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "openspout/openspout": "^4.1",
+        "openspout/openspout": "^4.8",
         "illuminate/support": "^8.71|^9.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "openspout/openspout": "^3.0|^4.0",
+        "openspout/openspout": "^4.0",
         "illuminate/support": "^8.71|^9.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "openspout/openspout": "^4.0",
+        "openspout/openspout": "^4.1",
         "illuminate/support": "^8.71|^9.0"
     },
     "require-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </coverage>
-  <testsuites>
-    <testsuite name="Spatie Test Suite">
-      <directory>tests</directory>
-    </testsuite>
-  </testsuites>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    executionOrder="random"
+    failOnWarning="true"
+    failOnRisky="true"
+    failOnEmptyTestSuite="true"
+    beStrictAboutOutputDuringTests="true"
+    verbose="true"
+>
+    <testsuites>
+        <testsuite name="Spatie Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <coverage>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+        <report>
+            <html outputDirectory="build/coverage"/>
+            <text outputFile="build/coverage.txt"/>
+            <clover outputFile="build/logs/clover.xml"/>
+        </report>
+    </coverage>
+    <logging>
+        <junit outputFile="build/report.junit.xml"/>
+    </logging>
 </phpunit>

--- a/src/ReaderFactory.php
+++ b/src/ReaderFactory.php
@@ -26,7 +26,7 @@ class ReaderFactory
     public static function createFromFile(
         string $path,
         CSVOptions|XLSXOptions|ODSOptions|null $options = null
-    ): ReaderInterface{
+    ): ReaderInterface {
         $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
 
         return match ($extension) {
@@ -49,7 +49,7 @@ class ReaderFactory
         string $path,
         CSVOptions|XLSXOptions|ODSOptions|null $options = null
     ): ReaderInterface {
-        if (!file_exists($path)) {
+        if (! file_exists($path)) {
             throw new IOException("Could not open {$path} for reading! File does not exist.");
         }
 

--- a/src/ReaderFactory.php
+++ b/src/ReaderFactory.php
@@ -66,9 +66,12 @@ class ReaderFactory
     }
 
     /**
-     * This creates an instance of the appropriate reader, given the type of the file to be read.
+     * @deprecated use createFromFileByMimeType() or createFromFile() instead
      *
-     * @param string $readerType Type of the reader to instantiate
+     * @param string $readerType
+     * @param CSVOptions|XLSXOptions|ODSOptions|null $options
+     * @return ReaderInterface
+     * @throws UnsupportedTypeException
      */
     public static function createFromType(
         string $readerType,

--- a/src/ReaderFactory.php
+++ b/src/ReaderFactory.php
@@ -12,8 +12,10 @@ use OpenSpout\Reader\ReaderInterface;
 use OpenSpout\Reader\XLSX\Options as XLSXOptions;
 use OpenSpout\Reader\XLSX\Reader as XLSXReader;
 
-/** @original \OpenSpout\Reader\Common\Creator\ReaderFactory */
-/** Overwritten so we can pass Options to the Reader classes */
+/**
+ * @internal overwritten from openspout/openspout so we can pass Options to the Reader classes
+ * Original: \OpenSpout\Reader\Common\Creator\ReaderFactory
+ */
 class ReaderFactory
 {
     /**
@@ -60,6 +62,23 @@ class ReaderFactory
             'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => new XLSXReader($options),
             'application/vnd.oasis.opendocument.spreadsheet' => new ODSReader($options),
             default => throw new UnsupportedTypeException('No readers supporting the given type: '.$mime_type),
+        };
+    }
+
+    /**
+     * This creates an instance of the appropriate reader, given the type of the file to be read.
+     *
+     * @param string $readerType Type of the reader to instantiate
+     */
+    public static function createFromType(
+        string $readerType,
+        CSVOptions|XLSXOptions|ODSOptions|null $options = null
+    ): ReaderInterface {
+        return match ($readerType) {
+            'csv' => new CSVReader($options),
+            'xlsx' => new XLSXReader($options),
+            'ods' => new ODSReader($options),
+            default => throw new UnsupportedTypeException('No readers supporting the given type: ' . $readerType),
         };
     }
 }

--- a/src/ReaderFactory.php
+++ b/src/ReaderFactory.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Spatie\SimpleExcel;
+
+use OpenSpout\Common\Exception\IOException;
+use OpenSpout\Common\Exception\UnsupportedTypeException;
+use OpenSpout\Reader\CSV\Options as CSVOptions;
+use OpenSpout\Reader\CSV\Reader as CSVReader;
+use OpenSpout\Reader\ODS\Options as ODSOptions;
+use OpenSpout\Reader\ODS\Reader as ODSReader;
+use OpenSpout\Reader\ReaderInterface;
+use OpenSpout\Reader\XLSX\Options as XLSXOptions;
+use OpenSpout\Reader\XLSX\Reader as XLSXReader;
+
+/** @original \OpenSpout\Reader\Common\Creator\ReaderFactory */
+/** Overwritten so we can pass Options to the Reader classes */
+class ReaderFactory
+{
+    /**
+     * Creates a reader by file extension.
+     *
+     * @param string $path The path to the spreadsheet file. Supported extensions are .csv,.ods and .xlsx
+     *
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     */
+    public static function createFromFile(
+        string $path,
+        CSVOptions|XLSXOptions|ODSOptions|null $options = null
+    ): ReaderInterface{
+        $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+
+        return match ($extension) {
+            'csv' => new CSVReader($options),
+            'xlsx' => new XLSXReader($options),
+            'ods' => new ODSReader($options),
+            default => throw new UnsupportedTypeException('No readers supporting the given type: '.$extension),
+        };
+    }
+
+    /**
+     * Creates a reader by mime type.
+     *
+     * @param string $path the path to the spreadsheet file
+     *
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Common\Exception\IOException
+     */
+    public static function createFromFileByMimeType(
+        string $path,
+        CSVOptions|XLSXOptions|ODSOptions|null $options = null
+    ): ReaderInterface {
+        if (!file_exists($path)) {
+            throw new IOException("Could not open {$path} for reading! File does not exist.");
+        }
+
+        $mime_type = mime_content_type($path);
+
+        return match ($mime_type) {
+            'application/csv', 'text/csv', 'text/plain' => new CSVReader($options),
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => new XLSXReader($options),
+            'application/vnd.oasis.opendocument.spreadsheet' => new ODSReader($options),
+            default => throw new UnsupportedTypeException('No readers supporting the given type: '.$mime_type),
+        };
+    }
+}

--- a/src/ReaderFactory.php
+++ b/src/ReaderFactory.php
@@ -68,9 +68,6 @@ class ReaderFactory
     /**
      * @deprecated use createFromFileByMimeType() or createFromFile() instead
      *
-     * @param string $readerType
-     * @param CSVOptions|XLSXOptions|ODSOptions|null $options
-     * @return ReaderInterface
      * @throws UnsupportedTypeException
      */
     public static function createFromType(

--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -47,7 +47,7 @@ class SimpleExcelReader
         $this->csvOptions = new CSVOptions();
 
         $this->reader = $this->type ?
-            ReaderFactory::createFromFileByMimeType($this->path) :
+            ReaderFactory::createFromType($this->type) :
             ReaderFactory::createFromFile($this->path);
 
         $this->setReader();
@@ -63,8 +63,8 @@ class SimpleExcelReader
             $options = $this->csvOptions;
         }
 
-        $this->reader = $this->type ?
-            ReaderFactory::createFromFileByMimeType($this->path, $options) :
+        $this->reader = !empty($this->type) ?
+            ReaderFactory::createFromType($this->type, $options) :
             ReaderFactory::createFromFile($this->path, $options);
     }
 

--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Spatie\SimpleExcel;
 
 use Illuminate\Support\LazyCollection;

--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -52,7 +52,7 @@ class SimpleExcelReader
         $this->setReader();
     }
 
-    protected function setReader(?CSVOptions $csvOptions = null): void
+    protected function setReader(): void
     {
         $options = null;
 
@@ -328,7 +328,7 @@ class SimpleExcelReader
 
     protected function getSheet(): SheetInterface
     {
-        $this->setReader($this->csvOptions);
+        $this->setReader();
 
         $this->reader->open($this->path);
         $sheet = ($this->searchSheetByName) ? $this->getActiveSheetByName() : $this->getActiveSheetByIndex();

--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -4,11 +4,10 @@ namespace Spatie\SimpleExcel;
 use Illuminate\Support\LazyCollection;
 use InvalidArgumentException;
 use OpenSpout\Common\Entity\Row;
-use OpenSpout\Reader\Common\Creator\ReaderEntityFactory;
 use OpenSpout\Reader\Common\Creator\ReaderFactory;
 use OpenSpout\Reader\CSV\Reader as CSVReader;
-use OpenSpout\Reader\IteratorInterface;
 use OpenSpout\Reader\ReaderInterface;
+use OpenSpout\Reader\RowIteratorInterface;
 use OpenSpout\Reader\SheetInterface;
 
 class SimpleExcelReader
@@ -16,7 +15,7 @@ class SimpleExcelReader
     protected string $path;
     protected string $type;
     protected ReaderInterface $reader;
-    protected IteratorInterface $rowIterator;
+    protected RowIteratorInterface $rowIterator;
     protected int $sheetNumber = 1;
     protected string $sheetName = "";
     protected bool $searchSheetByName = false;
@@ -44,8 +43,8 @@ class SimpleExcelReader
         $this->type = $type;
 
         $this->reader = $type ?
-            ReaderFactory::createFromType($type) :
-            ReaderEntityFactory::createReaderFromFile($this->path);
+            ReaderFactory::createFromFileByMimeType($path) :
+            ReaderFactory::createFromFile($path);
     }
 
     public function getPath(): string

--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -13,10 +13,6 @@ use OpenSpout\Reader\SheetInterface;
 
 class SimpleExcelReader
 {
-    /**
-     * @var callable
-     */
-    public $headerRowFormatter;
     protected ReaderInterface $reader;
     protected RowIteratorInterface $rowIterator;
     protected int $sheetNumber = 1;
@@ -263,13 +259,6 @@ class SimpleExcelReader
     protected function convertHeaders(callable $callback, array $headers): array
     {
         return array_map(fn ($header) => $callback($header), $headers);
-    }
-
-    public function headerRowFormatter(callable $callback): static
-    {
-        $this->headerRowFormatter = $callback;
-
-        return $this;
     }
 
     protected function trim(string $header): string

--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -63,7 +63,7 @@ class SimpleExcelReader
             $options = $this->csvOptions;
         }
 
-        $this->reader = !empty($this->type) ?
+        $this->reader = ! empty($this->type) ?
             ReaderFactory::createFromType($this->type, $options) :
             ReaderFactory::createFromFile($this->path, $options);
     }

--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -55,13 +55,7 @@ class SimpleExcelReader
 
     protected function setReader(): void
     {
-        $options = null;
-
-        if (isset($this->reader) &&
-            $this->reader instanceof CSVReader
-        ) {
-            $options = $this->csvOptions;
-        }
+        $options = $this->reader instanceof CSVReader ? $this->csvOptions : null;
 
         $this->reader = ! empty($this->type) ?
             ReaderFactory::createFromType($this->type, $options) :

--- a/src/SimpleExcelWriter.php
+++ b/src/SimpleExcelWriter.php
@@ -83,7 +83,9 @@ class SimpleExcelWriter
 
         $this->csvOptions = new CSVOptions();
 
-        $this->writer = WriterFactory::createFromFile($path);
+        $this->writer = !empty($type) ?
+            WriterFactory::createFromType($type) :
+            WriterFactory::createFromFile($this->path);
 
         if (($delimiter || $shouldAddBom) &&
             $this->writer instanceof Writer) {
@@ -95,7 +97,9 @@ class SimpleExcelWriter
                 $this->csvOptions->SHOULD_ADD_BOM = $shouldAddBom;
             }
 
-            $this->writer = WriterFactory::createFromFile($path, $this->csvOptions);
+            $this->writer = !empty($type) ?
+                WriterFactory::createFromType($type, $this->csvOptions) :
+                WriterFactory::createFromFile($this->path, $this->csvOptions);
         }
     }
 

--- a/src/SimpleExcelWriter.php
+++ b/src/SimpleExcelWriter.php
@@ -83,7 +83,7 @@ class SimpleExcelWriter
 
         $this->csvOptions = new CSVOptions();
 
-        $this->writer = !empty($type) ?
+        $this->writer = ! empty($type) ?
             WriterFactory::createFromType($type) :
             WriterFactory::createFromFile($this->path);
 
@@ -97,7 +97,7 @@ class SimpleExcelWriter
                 $this->csvOptions->SHOULD_ADD_BOM = $shouldAddBom;
             }
 
-            $this->writer = !empty($type) ?
+            $this->writer = ! empty($type) ?
                 WriterFactory::createFromType($type, $this->csvOptions) :
                 WriterFactory::createFromFile($this->path, $this->csvOptions);
         }

--- a/src/SimpleExcelWriter.php
+++ b/src/SimpleExcelWriter.php
@@ -12,8 +12,6 @@ class SimpleExcelWriter
 {
     private WriterInterface $writer;
 
-    private string $path = '';
-
     private bool $processHeader = true;
 
     private bool $processingFirstRow = true;
@@ -30,7 +28,7 @@ class SimpleExcelWriter
         callable $configureWriter = null,
         ?string $delimiter = null,
         ?bool $shouldAddBom = null,
-    ) {
+    ): static {
         $simpleExcelWriter = new static(
             path: $file,
             type: $type,
@@ -49,7 +47,7 @@ class SimpleExcelWriter
         return $simpleExcelWriter;
     }
 
-    public static function createWithoutBom(string $file, string $type = '')
+    public static function createWithoutBom(string $file, string $type = ''): static
     {
         return static::create(
             file: $file,
@@ -58,7 +56,7 @@ class SimpleExcelWriter
         );
     }
 
-    public static function streamDownload(string $downloadName, string $type = '', callable $writerCallback = null)
+    public static function streamDownload(string $downloadName, string $type = '', callable $writerCallback = null): static
     {
         $simpleExcelWriter = new static($downloadName, $type);
 
@@ -74,13 +72,11 @@ class SimpleExcelWriter
     }
 
     protected function __construct(
-        string $path,
+        private string $path,
         string $type = '',
         ?string $delimiter = null,
         ?bool $shouldAddBom = null,
     ) {
-        $this->path = $path;
-
         $this->csvOptions = new CSVOptions();
 
         $this->initWriter($path, $type);
@@ -90,9 +86,9 @@ class SimpleExcelWriter
 
     protected function initWriter(string $path, string $type, ?CSVOptions $options = null): void
     {
-        $this->writer = ! empty($type) ?
-            WriterFactory::createFromType($type, $options) :
-            WriterFactory::createFromFile($path, $options);
+        $this->writer = empty($type) ?
+            WriterFactory::createFromFile($path, $options) :
+            WriterFactory::createFromType($type, $options);
     }
 
     protected function addOptionsToWriter(
@@ -135,25 +131,21 @@ class SimpleExcelWriter
         return $this->numberOfRows;
     }
 
-    public function noHeaderRow()
+    public function noHeaderRow(): static
     {
         $this->processHeader = false;
 
         return $this;
     }
 
-    public function setHeaderStyle(Style $style)
+    public function setHeaderStyle(Style $style): static
     {
         $this->headerStyle = $style;
 
         return $this;
     }
 
-    /**
-     * @param \OpenSpout\Common\Entity\Row|array $row
-     * @param Style|null $style
-     */
-    public function addRow($row, Style $style = null)
+    public function addRow(Row|array $row, Style $style = null): static
     {
         if (is_array($row)) {
             if ($this->processHeader && $this->processingFirstRow) {
@@ -171,7 +163,7 @@ class SimpleExcelWriter
         return $this;
     }
 
-    public function addRows(iterable $rows, Style $style = null)
+    public function addRows(iterable $rows, Style $style = null): static
     {
         foreach ($rows as $row) {
             $this->addRow($row, $style);
@@ -192,7 +184,7 @@ class SimpleExcelWriter
         return $this;
     }
 
-    protected function writeHeaderFromRow(array $row)
+    protected function writeHeaderFromRow(array $row): void
     {
         $headerValues = array_keys($row);
 
@@ -222,10 +214,6 @@ class SimpleExcelWriter
 
     /**
      * Sets the name for the current sheet.
-     *
-     * @param  string  $name
-     *
-     * @return $this
      */
     public function nameCurrentSheet(string $name): self
     {
@@ -241,7 +229,7 @@ class SimpleExcelWriter
         exit;
     }
 
-    public function close()
+    public function close(): void
     {
         $this->writer->close();
     }

--- a/src/SimpleExcelWriter.php
+++ b/src/SimpleExcelWriter.php
@@ -105,11 +105,11 @@ class SimpleExcelWriter
             return;
         }
 
-        if ($delimiter) {
+        if ($delimiter !== null) {
             $this->csvOptions->FIELD_DELIMITER = $delimiter;
         }
 
-        if ($shouldAddBom) {
+        if ($shouldAddBom !== null) {
             $this->csvOptions->SHOULD_ADD_BOM = $shouldAddBom;
         }
 

--- a/src/WriterFactory.php
+++ b/src/WriterFactory.php
@@ -38,6 +38,14 @@ class WriterFactory
         };
     }
 
+    /**
+     * @deprecated use createFromFile() instead
+     *
+     * @param string $writerType
+     * @param CSVOptions|XLSXOptions|ODSOptions|null $options
+     * @return WriterInterface
+     * @throws UnsupportedTypeException
+     */
     public static function createFromType(
         string $writerType,
         CSVOptions|XLSXOptions|ODSOptions|null $options = null

--- a/src/WriterFactory.php
+++ b/src/WriterFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Spatie\SimpleExcel;
+
+use OpenSpout\Common\Exception\UnsupportedTypeException;
+use OpenSpout\Writer\CSV\Writer as CSVWriter;
+use OpenSpout\Writer\ODS\Writer as ODSWriter;
+use OpenSpout\Writer\WriterInterface;
+use OpenSpout\Writer\XLSX\Writer as XLSXWriter;
+use OpenSpout\Writer\CSV\Options as CSVOptions;
+use OpenSpout\Writer\ODS\Options as ODSOptions;
+use OpenSpout\Writer\XLSX\Options as XLSXOptions;
+
+class WriterFactory
+{
+    /**
+     * This creates an instance of the appropriate writer, given the extension of the file to be written.
+     *
+     * @param string $path The path to the spreadsheet file. Supported extensions are .csv,.ods and .xlsx
+     *
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     */
+    public static function createFromFile(
+        string $path,
+        CSVOptions|XLSXOptions|ODSOptions|null $options = null,
+    ): WriterInterface {
+        $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+
+        return match ($extension) {
+            'csv' => new CSVWriter($options),
+            'xlsx' => new XLSXWriter($options),
+            'ods' => new ODSWriter($options),
+            default => throw new UnsupportedTypeException('No writers supporting the given type: '.$extension),
+        };
+    }
+}

--- a/src/WriterFactory.php
+++ b/src/WriterFactory.php
@@ -41,9 +41,6 @@ class WriterFactory
     /**
      * @deprecated use createFromFile() instead
      *
-     * @param string $writerType
-     * @param CSVOptions|XLSXOptions|ODSOptions|null $options
-     * @return WriterInterface
      * @throws UnsupportedTypeException
      */
     public static function createFromType(

--- a/src/WriterFactory.php
+++ b/src/WriterFactory.php
@@ -11,6 +11,10 @@ use OpenSpout\Writer\WriterInterface;
 use OpenSpout\Writer\XLSX\Options as XLSXOptions;
 use OpenSpout\Writer\XLSX\Writer as XLSXWriter;
 
+/**
+ * @internal overwritten from openspout/openspout so we can pass Options to the Writer classes
+ * Original: \OpenSpout\Writer\Common\Creator\ReaderFactory
+ */
 class WriterFactory
 {
     /**
@@ -31,6 +35,18 @@ class WriterFactory
             'xlsx' => new XLSXWriter($options),
             'ods' => new ODSWriter($options),
             default => throw new UnsupportedTypeException('No writers supporting the given type: '.$extension),
+        };
+    }
+
+    public static function createFromType(
+        string $writerType,
+        CSVOptions|XLSXOptions|ODSOptions|null $options = null
+    ): WriterInterface {
+        return match ($writerType) {
+            'csv' => new CSVWriter($options),
+            'xlsx' => new XLSXWriter($options),
+            'ods' => new ODSWriter($options),
+            default => throw new UnsupportedTypeException('No writers supporting the given type: ' . $writerType),
         };
     }
 }

--- a/src/WriterFactory.php
+++ b/src/WriterFactory.php
@@ -3,13 +3,13 @@
 namespace Spatie\SimpleExcel;
 
 use OpenSpout\Common\Exception\UnsupportedTypeException;
+use OpenSpout\Writer\CSV\Options as CSVOptions;
 use OpenSpout\Writer\CSV\Writer as CSVWriter;
+use OpenSpout\Writer\ODS\Options as ODSOptions;
 use OpenSpout\Writer\ODS\Writer as ODSWriter;
 use OpenSpout\Writer\WriterInterface;
-use OpenSpout\Writer\XLSX\Writer as XLSXWriter;
-use OpenSpout\Writer\CSV\Options as CSVOptions;
-use OpenSpout\Writer\ODS\Options as ODSOptions;
 use OpenSpout\Writer\XLSX\Options as XLSXOptions;
+use OpenSpout\Writer\XLSX\Writer as XLSXWriter;
 
 class WriterFactory
 {

--- a/tests/SimpleExcelWriterTest.php
+++ b/tests/SimpleExcelWriterTest.php
@@ -47,8 +47,9 @@ test('add multiple rows', function () {
 });
 
 it('can use an alternative delimiter', function () {
-    SimpleExcelWriter::create($this->pathToCsv)
-        ->useDelimiter(';')
+    SimpleExcelWriter::create(
+        file: $this->pathToCsv,
+        delimiter: ';')
         ->addRow([
             'first_name' => 'John',
             'last_name' => 'Doe',

--- a/tests/SimpleExcelWriterTest.php
+++ b/tests/SimpleExcelWriterTest.php
@@ -2,6 +2,7 @@
 
 use OpenSpout\Writer\CSV\Writer;
 use Spatie\SimpleExcel\SimpleExcelWriter;
+
 use function Spatie\Snapshots\assertMatchesFileSnapshot;
 
 use Spatie\TemporaryDirectory\TemporaryDirectory;

--- a/tests/SimpleExcelWriterTest.php
+++ b/tests/SimpleExcelWriterTest.php
@@ -49,7 +49,8 @@ test('add multiple rows', function () {
 it('can use an alternative delimiter', function () {
     SimpleExcelWriter::create(
         file: $this->pathToCsv,
-        delimiter: ';')
+        delimiter: ';'
+    )
         ->addRow([
             'first_name' => 'John',
             'last_name' => 'Doe',

--- a/tests/__snapshots__/files/SimpleExcelWriterTest__it_can_write_a_csv_without_bom__1.csv
+++ b/tests/__snapshots__/files/SimpleExcelWriterTest__it_can_write_a_csv_without_bom__1.csv
@@ -1,2 +1,2 @@
-﻿first_name,last_name
+first_name,last_name
 Jane,Doe

--- a/tests/__snapshots__/files/SimpleExcelWriterTest__it_can_write_the_header_from_array__1.csv
+++ b/tests/__snapshots__/files/SimpleExcelWriterTest__it_can_write_the_header_from_array__1.csv
@@ -1,2 +1,2 @@
 ﻿first_name,last_name
-Jane,Doe
+John,Doe


### PR DESCRIPTION
openspout/openspout is at 4.8.1 by now. Their v3 does not support 8.2.

Main change on openspout/openspout v4.8 is that the Reader & Writer classes need Options (like a delimiter) when initialising them. This leads to removing `useDelimiter()` on our end. 

Also, the openspout/openspout Factory classes don't have a way to pass the Options, so they are moved to our codebase and adjusted.

More info in the Upgrade Guide!