### PR TITLE
Allow delimiter in streamDownload()

### DIFF
--- a/src/SimpleExcelWriter.php
+++ b/src/SimpleExcelWriter.php
@@ -56,9 +56,9 @@ class SimpleExcelWriter
         );
     }
 
-    public static function streamDownload(string $downloadName, string $type = '', callable $writerCallback = null): static
+    public static function streamDownload(string $downloadName, string $type = '', callable $writerCallback = null, ?string $delimiter = null): static
     {
-        $simpleExcelWriter = new static($downloadName, $type);
+        $simpleExcelWriter = new static($downloadName, $type, $delimiter);
 
         $writer = $simpleExcelWriter->getWriter();
 


### PR DESCRIPTION
With the 3.0 release the [`useDelimiter()` was removed](https://github.com/spatie/simple-excel/blob/main/UPGRADE.md#removed-usedelimiter-on-simpleexcelwriter). This PR allows defining a delimiter when using the `streamDownload` method.

Prior 3.x

```php
SimpleExcelWriter::streamDownload('your-export.csv')
     ->useDelimiter(';')
     ->addRow([
        'first_name' => 'John',
        'last_name' => 'Doe',
    ])
    ->addRow([
        'first_name' => 'Jane',
        'last_name' => 'Doe',
    ])
    ->toBrowser();
```


3.x

```php
SimpleExcelWriter::streamDownload(downloadName: 'your-export.csv', delimiter: ';')
     ->addRow([
        'first_name' => 'John',
        'last_name' => 'Doe',
    ])
    ->addRow([
        'first_name' => 'Jane',
        'last_name' => 'Doe',
    ])
    ->toBrowser();
```
