### PR TITLE
Drop use of deprecated method `createFromType`

### DIFF
--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -31,17 +31,17 @@ class SimpleExcelReader
     protected bool $useLimit = false;
     protected CSVOptions $csvOptions;
 
-    public static function create(string $file, string $type = ''): static
+    public static function create(string $file, bool $useMimeType = false): static
     {
-        return new static($file, $type);
+        return new static($file, $useMimeType);
     }
 
-    public function __construct(protected string $path, protected string $type = '')
+    public function __construct(protected string $path, protected bool $useMimeType = false)
     {
         $this->csvOptions = new CSVOptions();
 
-        $this->reader = $this->type ?
-            ReaderFactory::createFromType($this->type) :
+        $this->reader = $this->useMimeType ?
+            ReaderFactory::createFromFileByMimeType($this->path) :
             ReaderFactory::createFromFile($this->path);
 
         $this->setReader();
@@ -51,9 +51,9 @@ class SimpleExcelReader
     {
         $options = $this->reader instanceof CSVReader ? $this->csvOptions : null;
 
-        $this->reader = empty($this->type) ?
-            ReaderFactory::createFromFile($this->path, $options) :
-            ReaderFactory::createFromType($this->type, $options);
+        $this->reader = $this->useMimeType ?
+            ReaderFactory::createFromFileByMimeType($this->path, $options) :
+            ReaderFactory::createFromFile($this->path, $options);
     }
 
     public function getPath(): string

--- a/tests/SimpleExcelReaderTest.php
+++ b/tests/SimpleExcelReaderTest.php
@@ -1,7 +1,9 @@
 <?php
 
+use OpenSpout\Common\Exception\UnsupportedTypeException;
 use OpenSpout\Reader\CSV\Reader;
 use Spatie\SimpleExcel\SimpleExcelReader;
+use function Pest\testDirectory;
 
 it('can work with an empty field', function () {
     $actualCount = SimpleExcelReader::create(getStubPath('empty.csv'))
@@ -367,11 +369,16 @@ it('can call `first` on the collection twice', function () {
     expect([$firstRow, $firstRowAgain])->not->toBeNull();
 });
 
-it('allows setting the reader type manually', function () {
-    $reader = SimpleExcelReader::create('php://input', 'csv');
+it('allows setting the reader type from the mime type', function () {
+    $csvReader = SimpleExcelReader::create(testDirectory('stubs/header-and-rows.csv'),true);
 
-    expect($reader->getReader())->toBeInstanceOf(Reader::class);
+    expect($csvReader->getReader())->toBeInstanceOf(Reader::class);
 });
+
+it(
+    'fails to set the reader based on mime type for empty file',
+    fn () => SimpleExcelReader::create(testDirectory('stubs/empty.csv'),true)
+)->expectException(UnsupportedTypeException::class);
 
 it('can trim the header row names', function () {
     $rows = SimpleExcelReader::create(getStubPath('header-with-spaces.csv'))


### PR DESCRIPTION
This PR drops use of the deprecated method `createFromType` in the `SimpleExcelReader` class. Insread, it adds support for the new `createFromFileByMimeType` method by passing a second parameter (as boolean) to the create method. See example below

```php
use Spatie\SimpleExcel\SimpleExcelReader;

SimpleExcelReader::create(file: 'contacts.csv', useMimeType: true)
```