### PR TITLE
Allow `shouldAddBom` in `streamDownload`

### DIFF
--- a/src/SimpleExcelWriter.php
+++ b/src/SimpleExcelWriter.php
@@ -56,9 +56,14 @@ class SimpleExcelWriter
         );
     }
 
-    public static function streamDownload(string $downloadName, string $type = '', callable $writerCallback = null, ?string $delimiter = null): static
-    {
-        $simpleExcelWriter = new static($downloadName, $type, $delimiter);
+    public static function streamDownload(
+        string $downloadName,
+        string $type = '',
+        callable $writerCallback = null,
+        ?string $delimiter = null,
+        ?bool $shouldAddBom = null,
+    ): static {
+        $simpleExcelWriter = new static($downloadName, $type, $delimiter, $shouldAddBom);
 
         $writer = $simpleExcelWriter->getWriter();
 


### PR DESCRIPTION
In 2.x you can disable `BOM` like that:

```php
$writer = SimpleExcelWriter::streamDownload('file.csv', 'csv', function ($writer) {
    $writer->setShouldAddBOM(false);
});
```

But in 3.x it isn't possible.

This PR allows defining a `shouldAddBom` when using the streamDownload method.