### PR TITLE
Add documentation for closing the file manually when necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,12 @@ $writer = SimpleExcelWriter::create($pathToCsv)
 #### Writing an Excel file
 
 Writing an Excel file is identical to writing a csv. Just make sure that the path given to the `create` method of `SimpleExcelWriter` ends with `xlsx`.
+One other thing to be aware of when writing an Excel file is that the file doesn't get written until the instance of `SimpleExcelWriter` is garbage collected.
+That's when the `close` method is called. The `close` method is what finalizes writing the file to disk. If you need to access the file before the instance is garbage collected you will need to call the `close` method first.
 
+```php
+$writer->close();
+```
 
 #### Streaming an Excel file to the browser
 


### PR DESCRIPTION
I came across a situation where I was trying to write to an Excel file but the file was empty. The reason was that for Excel files the file doesn't get written until the destructor is called. So I figured I'll make a PR to add it to the documentation. 