### PR TITLE
Fix openspout backwards compatibility change that stops parsing formulas

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,15 +10,13 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.2, 8.1]
-        laravel: [10.*, 9.*, 8.*]
+        laravel: [10.*, 9.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
             testbench: 8.*
           - laravel: 9.*
             testbench: 7.*
-          - laravel: 8.*
-            testbench: ^6.23
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.1, 8.0]
+        php: [8.2, 8.1]
         laravel: [10.*, 9.*, 8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
@@ -19,10 +19,6 @@ jobs:
             testbench: 7.*
           - laravel: 8.*
             testbench: ^6.23
-        exclude:
-          - laravel: 10.*
-            php: 8.0
-
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ If your file already contains a header row, it will be ignored and replaced with
 
 If your file does not contain a header row, you should also use `noHeaderRow()`, and your headers will be used instead of numeric keys, as above.
 
-### Working with multiple sheet documents
+#### Working with multiple sheet documents
 
 Excel files can include multiple spreadsheets. You can select the sheet you want to use with the `fromSheet()` method to select by index.
 
@@ -271,6 +271,16 @@ The `skip` method allows you to define which row to start reading data from. In 
 $rows = SimpleExcelReader::create($pathToCsv)
     ->skip(10)
     ->take(5)
+    ->getRows();
+```
+
+#### Reading cells that contain formulas
+
+Normally, cells containing formulas are parsed and their computed value will be returned. If you want to keep the actual formula as a string, you can use the `keepFormulas` method.
+
+```php
+$rows = SimpleExcelReader::create($pathToXlsx)
+    ->keepFormulas()
     ->getRows();
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "openspout/openspout": "^4.19",
         "illuminate/support": "^8.71|^9.0|^10.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.1",
         "openspout/openspout": "^4.19",
-        "illuminate/support": "^8.71|^9.0|^10.0"
+        "illuminate/support": "^9.0|^10.0"
     },
     "require-dev": {
         "pestphp/pest-plugin-laravel": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "openspout/openspout": "^4.8",
+        "openspout/openspout": "^4.19",
         "illuminate/support": "^8.71|^9.0|^10.0"
     },
     "require-dev": {


### PR DESCRIPTION
Openspout 4.16 introduced a change that returns formulas verbatim instead of interpreting the result (see openspout/openspout#169).

This PR prevents this BC change for simple-excel users while introducing a new `keepFormulas` method that allows for the new openspout behavior.

The new minimum version of openspout has been set to 4.19 because interim versions added several fixes to the formula behavior.