### PR TITLE
Add the option to check if a sheet exists by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,13 @@ $rows = SimpleExcelReader::create($pathToXlsx)
     ->getRows();
 ```
 
+if you want to check if a sheet exists, you can use the `sheetExists()` method.
+
+```php  
+$sheetExists = SimpleExcelReader::create($pathToXlsx)
+    ->sheetExists("sheet1");
+```
+
 #### Retrieving header row values
 
 If you would like to retrieve the header row as an array, you can use the `getHeaders()` method.

--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -152,6 +152,20 @@ class SimpleExcelReader
         return $this;
     }
 
+    public function hasSheet(string $sheetName) : bool
+    {
+        $this->setReader();
+
+        $this->reader->open($this->path);
+
+        foreach ($this->reader->getSheetIterator() as $sheet) {
+            if ($sheetName != "" && $sheetName === $sheet->getName()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public function fromSheet(int $sheetNumber): SimpleExcelReader
     {
         $this->sheetNumber = $sheetNumber;

--- a/tests/SimpleExcelReaderTest.php
+++ b/tests/SimpleExcelReaderTest.php
@@ -590,6 +590,18 @@ it('can select the sheet of an excel file by name', function () {
     ]);
 });
 
+it('Can check if a sheet exists by name', function () {
+    $reader = SimpleExcelReader::create(getStubPath('multiple_sheets.xlsx'));
+
+    expect($reader->hasSheet("sheet1"))->toBeTrue();
+});
+
+it('Can check if a sheet doesn\'t exists by name', function () {
+    $reader = SimpleExcelReader::create(getStubPath('multiple_sheets.xlsx'));
+
+    expect($reader->hasSheet("sheet0"))->toBeFalse();
+});
+
 it('will not open non-existing sheets by name', function () {
     SimpleExcelReader::create(getStubPath('multiple_sheets.xlsx'))
         ->fromSheetName("sheetNotExists")


### PR DESCRIPTION
When using the package to read invoices, I came across the issue where some invoices didn't have a certain sheet. So I added the possibility to check if the sheets exists.

```php  
$sheetExists = SimpleExcelReader::create($pathToXlsx)
    ->sheetExists("sheet1");
```