### PR TITLE
Allow Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
     "require": {
         "php": "^8.1",
         "openspout/openspout": "^4.19",
-        "illuminate/support": "^9.0|^10.0"
+        "illuminate/support": "^9.0|^10.0|^11.0"
     },
     "require-dev": {
-        "pestphp/pest-plugin-laravel": "^1.3",
-        "phpunit/phpunit": "^9.4",
-        "spatie/pest-plugin-snapshots": "^1.1",
-        "spatie/phpunit-snapshot-assertions": "^4.0",
-        "spatie/temporary-directory": "^1.2"
+        "pestphp/pest-plugin-laravel": "^1.3|^2.2",
+        "phpunit/phpunit": "^9.4|^10.5",
+        "spatie/pest-plugin-snapshots": "^1.1|^2.1",
+        "spatie/phpunit-snapshot-assertions": "^4.0|^5.1",
+        "spatie/temporary-directory": "^1.2|^2.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I've worked out the necessary dependencies for composer and the ci workflows will work fine as is, but I was unable to get the ci worklows running properly for L11 so I've left them alone for now. Perhaps someone can help?

The main issue I believe is that L11 drops support for php8.1. I'm comfortable submitting proposed changes in composer.json for added support, however when it comes to dropping support for php8.1 etc. (if necessary), maintainers are free to edit this PR!

What I've tried:
 
```diff
      matrix:
-        php: [8.2, 8.1]
-        laravel: [ 10.*, 9.*]
+        php: [8.3, 8.2, 8.1]
+       laravel: [11.*, 10.*, 9.*]
...
        include:
+        - laravel: 11.*
+          testbench: 9.*
```

I tried the above changes and let the workflows run on my own forked repo, however it didn't work because when it ran for L11 it started with php8.1, which led to an unresolvable dependencies error.  