### PR TITLE
CSV stream callback fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,41 @@ foreach (range(1, 10_000) as $i) {
 $writer->toBrowser();
 ```
 
+Stream download using callback function
+
+```php
+use Spatie\SimpleExcel\SimpleExcelWriter;
+use OpenSpout\Common\Entity\Row;
+
+$writer = SimpleExcelWriter::streamDownload(downloadName: 'user-list.xlsx', writerCallback: function ($writerCallback, $downloadName) {
+    
+    $writerCallback->openToBrowser($downloadName);
+
+    $writerCallback->addRow(Row::fromValues([
+        'first_name' => 'First Name',
+        'last_name' => 'Last Name',
+    ]));
+
+    $writerCallback->addRow(Row::fromValues([
+        'first_name' => 'Rakib',
+        'last_name' => 'Hossain',
+    ]));
+
+    foreach (range(1, 10_000) as $i) {
+        $writerCallback->addRow(Row::fromValues([
+            'first_name' => 'Rakib',
+            'last_name' => 'Hossain',
+        ]));
+
+        if ($i % 1000 === 0) {
+            flush();
+        }
+    }
+});
+
+$writer->toBrowser();
+```
+
 
 ### Writing multiple rows at once
 

--- a/README.md
+++ b/README.md
@@ -376,13 +376,13 @@ foreach (range(1, 10_000) as $i) {
 $writer->toBrowser();
 ```
 
-Stream download using callback function
+You could also use a callback.
 
 ```php
 use Spatie\SimpleExcel\SimpleExcelWriter;
 use OpenSpout\Common\Entity\Row;
 
-$writer = SimpleExcelWriter::streamDownload(downloadName: 'user-list.xlsx', writerCallback: function ($writerCallback, $downloadName) {
+$writer = SimpleExcelWriter::streamDownload('user-list.xlsx', function ($writerCallback, $downloadName) {
     
     $writerCallback->openToBrowser($downloadName);
 

--- a/src/SimpleExcelWriter.php
+++ b/src/SimpleExcelWriter.php
@@ -67,11 +67,9 @@ class SimpleExcelWriter
 
         $writer = $simpleExcelWriter->getWriter();
 
-        if ($writerCallback) {
-            $writerCallback($writer, $downloadName);
-        } else {
+        $writerCallback ?
+            $writerCallback($writer, $downloadName) :
             $writer->openToBrowser($downloadName);
-        }
 
         return $simpleExcelWriter;
     }

--- a/src/SimpleExcelWriter.php
+++ b/src/SimpleExcelWriter.php
@@ -68,10 +68,10 @@ class SimpleExcelWriter
         $writer = $simpleExcelWriter->getWriter();
 
         if ($writerCallback) {
-            $writerCallback($writer);
+            $writerCallback($writer, $downloadName);
+        } else {
+            $writer->openToBrowser($downloadName);
         }
-
-        $writer->openToBrowser($downloadName);
 
         return $simpleExcelWriter;
     }


### PR DESCRIPTION
If we use callback to write content, we must open the OpenSpout writer. So it basically calls twice, which makes problem on CSV.

`openToBrowser` function also need the file name inside closure. So I've added the `$downloadName` as an argument.