### PR TITLE
Fix deprecation warning for PHP 8.4 implicit nullable parameter

### DIFF
--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -138,7 +138,7 @@ class SimpleExcelReader
         return $this;
     }
 
-    public function trimHeaderRow(string $characters = null): self
+    public function trimHeaderRow(?string $characters = null): self
     {
         $this->trimHeader = true;
         $this->trimHeaderCharacters = $characters;

--- a/src/SimpleExcelWriter.php
+++ b/src/SimpleExcelWriter.php
@@ -25,7 +25,7 @@ class SimpleExcelWriter
     public static function create(
         string $file,
         string $type = '',
-        callable $configureWriter = null,
+        ?callable $configureWriter = null,
         ?string $delimiter = null,
         ?bool $shouldAddBom = null,
     ): static {
@@ -59,7 +59,7 @@ class SimpleExcelWriter
     public static function streamDownload(
         string $downloadName,
         string $type = '',
-        callable $writerCallback = null,
+        ?callable $writerCallback = null,
         ?string $delimiter = null,
         ?bool $shouldAddBom = null,
     ): static {
@@ -148,7 +148,7 @@ class SimpleExcelWriter
         return $this;
     }
 
-    public function addRow(Row|array $row, Style $style = null): static
+    public function addRow(Row|array $row, ?Style $style = null): static
     {
         if (is_array($row)) {
             if ($this->processHeader && $this->processingFirstRow) {
@@ -166,7 +166,7 @@ class SimpleExcelWriter
         return $this;
     }
 
-    public function addRows(iterable $rows, Style $style = null): static
+    public function addRows(iterable $rows, ?Style $style = null): static
     {
         foreach ($rows as $row) {
             $this->addRow($row, $style);


### PR DESCRIPTION
Since PHP 8.4 Implicitly marking parameters as nullable is deprecated, the explicit nullable type must be used instead.

For example change `Style $style = null` => `?Style $style = null`