### PR TITLE
Always determine reader type based on mime type

### DIFF
--- a/src/ReaderFactory.php
+++ b/src/ReaderFactory.php
@@ -64,21 +64,4 @@ class ReaderFactory
             default => throw new UnsupportedTypeException('No readers supporting the given type: '.$mime_type),
         };
     }
-
-    /**
-     * @deprecated use createFromFileByMimeType() or createFromFile() instead
-     *
-     * @throws UnsupportedTypeException
-     */
-    public static function createFromType(
-        string $readerType,
-        CSVOptions|XLSXOptions|ODSOptions|null $options = null
-    ): ReaderInterface {
-        return match ($readerType) {
-            'csv' => new CSVReader($options),
-            'xlsx' => new XLSXReader($options),
-            'ods' => new ODSReader($options),
-            default => throw new UnsupportedTypeException('No readers supporting the given type: ' . $readerType),
-        };
-    }
 }

--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -47,7 +47,7 @@ class SimpleExcelReader
         $this->csvOptions = new CSVOptions();
         $this->xlsxOptions = new XLSXOptions();
 
-        $this->reader = ReaderFactory::createFromFile($this->path);
+        $this->reader = ReaderFactory::createFromFileByMimeType($this->path);
 
         $this->setReader();
     }
@@ -60,7 +60,7 @@ class SimpleExcelReader
             default => null,
         };
 
-        $this->reader = ReaderFactory::createFromFile($this->path, $options);
+        $this->reader = ReaderFactory::createFromFileByMimeType($this->path, $options);
     }
 
     public function getPath(): string

--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -37,19 +37,17 @@ class SimpleExcelReader
     protected CSVOptions $csvOptions;
     protected XLSXOptions $xlsxOptions;
 
-    public static function create(string $file, string $type = ''): static
+    public static function create(string $file): static
     {
-        return new static($file, $type);
+        return new static($file);
     }
 
-    public function __construct(protected string $path, protected string $type = '')
+    public function __construct(protected string $path)
     {
         $this->csvOptions = new CSVOptions();
         $this->xlsxOptions = new XLSXOptions();
 
-        $this->reader = $this->type ?
-            ReaderFactory::createFromType($this->type) :
-            ReaderFactory::createFromFile($this->path);
+        $this->reader = ReaderFactory::createFromFile($this->path);
 
         $this->setReader();
     }
@@ -62,9 +60,7 @@ class SimpleExcelReader
             default => null,
         };
 
-        $this->reader = empty($this->type) ?
-            ReaderFactory::createFromFile($this->path, $options) :
-            ReaderFactory::createFromType($this->type, $options);
+        $this->reader = ReaderFactory::createFromFile($this->path, $options);
     }
 
     public function getPath(): string


### PR DESCRIPTION
This PR does the following:
1. Removes the deprecated `createFromType` method and corresponding `type` property from `SimpleExcelReader`.
2. Replaces calls to `createFromFile` with the `createFromFileByMimeType` method exclusively.

The reason for replacing calls to `createFromFile` is to allow any file to be processed correctly despite the file name. This is especially important when the original file has been renamed and no longer has a file extension. When working with uploaded files, the file name is always renamed to a generated string without the original extension. Always using `createFromFileByMimeType` should simplify the reader type detection and make it more consistent, since it is not dependent on the file extension.

This is a breaking change, so it will need to be released in the next major version.