### PR TITLE
Rewind iterator after use

### DIFF
--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -244,6 +244,12 @@ class SimpleExcelReader
 
                 $this->rowIterator->next();
             }
+            $this->rowIterator->rewind();
+
+            if ($this->processHeader) {
+                $this->getHeaders();
+                $this->rowIterator->next();
+            }
         });
     }
 

--- a/tests/SimpleExcelReaderTest.php
+++ b/tests/SimpleExcelReaderTest.php
@@ -643,3 +643,18 @@ it('can preserve empty rows', function () {
     expect($reader->getRows()->count())->toBe(2);
     expect($reader->preserveEmptyRows()->getRows()->count())->toBe(3);
 });
+
+it('can count and take rows', function () {
+    $reader = SimpleExcelReader::create(getStubPath('header-and-rows.csv'));
+
+    $lazyCollection = $reader->getRows();
+
+    expect($lazyCollection->count())->toBe(2);
+    expect($lazyCollection->take(1)->all())->toEqual([
+        [
+            'email' => 'john@example.com',
+            'first_name' => 'john',
+            'last_name' => 'doe',
+        ],
+    ]);
+});


### PR DESCRIPTION
In order to be able to count and retrieve data from the same lazy collection (use case; add a filter to the lazy collection returned by `getRows()` and pass that on), it has to rewind the `rowIterator` to after the header