### PR TITLE
Bump openspout/openspout to v4.30.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.3",
         "illuminate/support": "^9.0|^10.0|^11.0|^12.0",
         "openspout/openspout": "^4.30"
     },


### PR DESCRIPTION
This PR updates the version of `openspout/openspout` to `v4.30.1` so that we can take advantage of the latest updates in that package.

The currently pinned version is `v4.19` which was released in October of 2023. There have been many improvements to the package in that time. 

One of the updates will fix crashes like these `Argument #1 ($numFmtId) must be of type int, null given` due to malformed excel sheets with improper styles.

### Testing
Ran the full test suite against the new version of openspout and confirmed it successfully completed ✅ 

