### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.4, 8.3]
+        php: [8.5, 8.4, 8.3]
         laravel: ['11.*', '12.*']
         dependency-version: [prefer-lowest, prefer-stable]
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,8 +1,6 @@
 name: run-tests
 
-on:
-  - push
-  - pull_request
+on: [push, pull_request]
 
 jobs:
   test:
@@ -12,14 +10,21 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.5, 8.4, 8.3]
-        laravel: ['11.*', '12.*']
-        dependency-version: [prefer-lowest, prefer-stable]
+        laravel: ['13.*', '12.*', '11.*']
+        stability: [prefer-stable]
+        include:
+          - laravel: 13.*
+            testbench: 11.*
+          - laravel: 12.*
+            testbench: 10.*
+          - laravel: 11.*
+            testbench: 9.*
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -30,8 +35,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
         run: vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.3",
-        "illuminate/support": "^9.0|^10.0|^11.0|^12.0",
+        "illuminate/support": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "openspout/openspout": "^4.30"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
         "openspout/openspout": "^4.30"
     },
     "require-dev": {
-        "pestphp/pest-plugin-laravel": "^1.3|^2.3|^3.0",
         "phpunit/phpunit": "^9.4|^10.5|^11.0|^12.0",
         "spatie/pest-plugin-snapshots": "^1.1|^2.1",
         "spatie/phpunit-snapshot-assertions": "^4.0|^5.1",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,17 +23,4 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
-    <logging>
-        <junit outputFile="build/report.junit.xml"/>
-    </logging>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,12 +3,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
-    backupStaticAttributes="false"
     bootstrap="vendor/autoload.php"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
     executionOrder="random"
@@ -16,7 +12,6 @@
     failOnRisky="true"
     failOnEmptyTestSuite="true"
     beStrictAboutOutputDuringTests="true"
-    verbose="true"
 >
     <testsuites>
         <testsuite name="Spatie Test Suite">

--- a/tests/SimpleExcelWriterTest.php
+++ b/tests/SimpleExcelWriterTest.php
@@ -114,7 +114,7 @@ test('the writer can get the path', function () {
 });
 
 it('allows setting the writer type manually', function () {
-    $writer = SimpleExcelWriter::create('php://output', 'csv');
+    $writer = SimpleExcelWriter::create($this->pathToCsv, 'csv');
 
     expect($writer->getWriter())->toBeInstanceOf(Writer::class);
 });


### PR DESCRIPTION
## Summary
- Add Laravel 13 support
- Add PHP 8.5 to test matrix
- Fix coverage warnings
- Update test dependencies (Pest 4, PHPUnit 12, Testbench 11)