### PR TITLE
Add trimValues() and formatValuesUsing() to the reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,46 @@ $rows = SimpleExcelReader::create($pathToCsv)
     });
 ```
 
+#### Trimming and formatting values
+
+Just like you can clean up header names, you can clean up the data values themselves. This is handy when importing files where cells contain stray whitespace or need to be normalized.
+
+Use `trimValues()` to strip whitespace from every value.
+
+```csv
+email,first_name
+  john@example.com  ,  john
+jane@example.com,jane
+```
+
+```php
+$rows = SimpleExcelReader::create($pathToCsv)
+    ->trimValues()
+    ->getRows()
+    ->each(function(array $rowProperties) {
+       // in the first pass $rowProperties will contain
+       // ['email' => 'john@example.com', 'first_name' => 'john']
+    });
+```
+
+Like `trim`, `trimValues()` accepts an optional argument specifying which characters to trim. This argument is a *set of characters* stripped from both ends of each value (exactly like PHP's [`trim`](https://www.php.net/manual/en/function.trim.php)), **not** a suffix. For example, `trimValues('*')` removes any leading or trailing `*` from every value. Be careful with letters: `trimValues('.com')` would also turn `Tom` into `T`.
+
+```php
+$rows = SimpleExcelReader::create($pathToCsv)
+    ->trimValues('*')
+    ->getRows();
+```
+
+For full control, use `formatValuesUsing()` and pass a closure. The closure receives the value and its header key, so you can normalize values per column. Non-string values (such as dates read from an Excel file) are passed through untouched by `trimValues()`, but your own closure is responsible for handling them.
+
+```php
+$rows = SimpleExcelReader::create($pathToCsv)
+    ->formatValuesUsing(function ($value, $key) {
+        return $key === 'email' ? strtolower($value) : $value;
+    })
+    ->getRows();
+```
+
 #### Manually working with the reader object
 
 Under the hood this package uses the [openspout/spout](https://github.com/openspout/openspout) package. You can get to the underlying reader that implements `\OpenSpout\Reader\ReaderInterface` by calling the `getReader` method.

--- a/src/SimpleExcelReader.php
+++ b/src/SimpleExcelReader.php
@@ -26,6 +26,9 @@ class SimpleExcelReader
     protected bool $trimHeader = false;
     protected bool $headersToSnakeCase = false;
     protected bool $parseFormulas = true;
+    protected bool $trimValues = false;
+    protected ?string $trimValueCharacters = null;
+    protected mixed $formatValuesUsing = null;
     protected ?string $trimHeaderCharacters = null;
     protected mixed $formatHeadersUsing = null;
     protected ?array $headers = null;
@@ -156,6 +159,21 @@ class SimpleExcelReader
     public function headersToSnakeCase(): self
     {
         $this->headersToSnakeCase = true;
+
+        return $this;
+    }
+
+    public function trimValues(?string $characters = null): self
+    {
+        $this->trimValues = true;
+        $this->trimValueCharacters = $characters;
+
+        return $this;
+    }
+
+    public function formatValuesUsing(callable $callback): self
+    {
+        $this->formatValuesUsing = $callback;
 
         return $this;
     }
@@ -376,7 +394,7 @@ class SimpleExcelReader
         $headers = $this->customHeaders ?: $this->headers;
 
         if (! $headers) {
-            return $values;
+            return $this->processValues($values);
         }
 
         $values = array_slice($values, 0, count($headers));
@@ -385,7 +403,33 @@ class SimpleExcelReader
             $values[] = '';
         }
 
-        return array_combine($headers, $values);
+        return $this->processValues(array_combine($headers, $values));
+    }
+
+    protected function processValues(array $values): array
+    {
+        if ($this->trimValues) {
+            $values = array_map([$this, 'trimValue'], $values);
+        }
+
+        if ($this->formatValuesUsing) {
+            $keys = array_keys($values);
+            $formatted = array_map($this->formatValuesUsing, array_values($values), $keys);
+            $values = array_combine($keys, $formatted);
+        }
+
+        return $values;
+    }
+
+    protected function trimValue(mixed $value): mixed
+    {
+        if (! is_string($value)) {
+            return $value;
+        }
+
+        return is_null($this->trimValueCharacters)
+            ? trim($value)
+            : trim($value, $this->trimValueCharacters);
     }
 
     protected function getSheet(): SheetInterface

--- a/tests/SimpleExcelReaderTest.php
+++ b/tests/SimpleExcelReaderTest.php
@@ -573,12 +573,12 @@ it('can format values when there is no header row', function () {
         ->noHeaderRow()
         ->trimValues()
         ->getRows()
-        ->first();
+        ->toArray();
 
     expect($rows)->toEqual([
-        0 => 'email',
-        1 => 'first_name',
-        2 => 'last_name',
+        ['email', 'first_name', 'last_name'],
+        ['john@example.com', 'john', 'doe'],
+        ['mary-jane@example.com', 'mary jane', 'doe'],
     ]);
 });
 

--- a/tests/SimpleExcelReaderTest.php
+++ b/tests/SimpleExcelReaderTest.php
@@ -496,6 +496,103 @@ it('can retrieve headers with a custom formatter', function () {
     ]);
 });
 
+it('can trim whitespace from values', function () {
+    $rows = SimpleExcelReader::create(getStubPath('values-with-spaces.csv'))
+        ->trimValues()
+        ->getRows()
+        ->toArray();
+
+    expect($rows)->toEqual([
+        [
+            'email' => 'john@example.com',
+            'first_name' => 'john',
+            'last_name' => 'doe',
+        ],
+        [
+            'email' => 'mary-jane@example.com',
+            'first_name' => 'mary jane',
+            'last_name' => 'doe',
+        ],
+    ]);
+});
+
+it('can trim values with custom characters', function () {
+    $rows = SimpleExcelReader::create(getStubPath('padded-values.csv'))
+        ->trimValues('*')
+        ->getRows()
+        ->first();
+
+    expect($rows)->toEqual([
+        'email' => 'john@example.com',
+        'first_name' => 'john',
+    ]);
+});
+
+it('can format values using a callback', function () {
+    $rows = SimpleExcelReader::create(getStubPath('header-and-rows.csv'))
+        ->formatValuesUsing(fn ($value) => strtoupper($value))
+        ->getRows()
+        ->first();
+
+    expect($rows)->toEqual([
+        'email' => 'JOHN@EXAMPLE.COM',
+        'first_name' => 'JOHN',
+        'last_name' => 'DOE',
+    ]);
+});
+
+it('passes the header key to the value formatter', function () {
+    $rows = SimpleExcelReader::create(getStubPath('header-and-rows.csv'))
+        ->formatValuesUsing(fn ($value, $key) => $key === 'email' ? strtoupper($value) : $value)
+        ->getRows()
+        ->first();
+
+    expect($rows)->toEqual([
+        'email' => 'JOHN@EXAMPLE.COM',
+        'first_name' => 'john',
+        'last_name' => 'doe',
+    ]);
+});
+
+it('can trim and format values together', function () {
+    $rows = SimpleExcelReader::create(getStubPath('values-with-spaces.csv'))
+        ->trimValues()
+        ->formatValuesUsing(fn ($value) => strtoupper($value))
+        ->getRows()
+        ->first();
+
+    expect($rows)->toEqual([
+        'email' => 'JOHN@EXAMPLE.COM',
+        'first_name' => 'JOHN',
+        'last_name' => 'DOE',
+    ]);
+});
+
+it('can format values when there is no header row', function () {
+    $rows = SimpleExcelReader::create(getStubPath('values-with-spaces.csv'))
+        ->noHeaderRow()
+        ->trimValues()
+        ->getRows()
+        ->first();
+
+    expect($rows)->toEqual([
+        0 => 'email',
+        1 => 'first_name',
+        2 => 'last_name',
+    ]);
+});
+
+it('does not trim non-string values', function () {
+    $dates = SimpleExcelReader::create(getStubPath('formatted_dates.xlsx'))
+        ->trimValues()
+        ->getRows()
+        ->pluck('created_at')
+        ->toArray();
+
+    expect($dates[0])->toBeInstanceOf(DateTimeImmutable::class);
+    expect($dates[1])->toBeInstanceOf(DateTimeImmutable::class);
+});
+
 it('can retrieve rows with a different delimiter', function () {
     $rows = SimpleExcelReader::create(getStubPath('header-and-rows-other-delimiter.csv'))
         ->useDelimiter(';')

--- a/tests/stubs/padded-values.csv
+++ b/tests/stubs/padded-values.csv
@@ -1,0 +1,2 @@
+email,first_name
+*john@example.com*,*john*

--- a/tests/stubs/values-with-spaces.csv
+++ b/tests/stubs/values-with-spaces.csv
@@ -1,0 +1,3 @@
+email,first_name,last_name
+  john@example.com  ,  john,doe
+mary-jane@example.com,mary jane  ,  doe


### PR DESCRIPTION
## Why

The reader can already clean up **header names** (`trimHeaderRow()`, `headersToSnakeCase()`, `formatHeadersUsing()`) but offers nothing for the **values themselves**. Importing user-supplied files usually means dealing with stray whitespace or values that need normalizing, which today forces a manual `->map()` over every row.

## What

Two symmetric reader methods:

- `trimValues(?string $characters = null)` — trims whitespace (or the given characters) from every value. The argument is a *set of characters* stripped from both ends, like PHP's `trim`. Non-string values (e.g. dates) are left untouched.
- `formatValuesUsing(callable $callback)` — runs each value through a closure receiving `($value, $key)`, so values can be normalized per column.

Formatting happens per row inside the `LazyCollection` generator, so the package keeps its low memory usage. Includes tests and README docs.

## Open question for discussion

I gave `trimValues()` an optional `$characters` argument to mirror the existing `trimHeaderRow($characters)`. It has one sharp edge: since it's passed straight to PHP's `trim()`, the argument is a *set of characters* stripped from both ends — not a suffix. So `trimValues('.com')` would also turn `Tom` into `T`, which is easy to misread.

Because `formatValuesUsing()` already lets callers do any custom trimming with full control, I'm happy to drop the `$characters` argument and keep `trimValues()` as a simple whitespace-only helper if you'd prefer. Let me know which way you'd like it.

